### PR TITLE
Support store key-value in DB

### DIFF
--- a/app/schemas/one.mixin.android.db.MixinDatabase/40.json
+++ b/app/schemas/one.mixin.android.db.MixinDatabase/40.json
@@ -1,0 +1,2081 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 40,
+    "identityHash": "6e545c6d5a47c95c77fdd7150d5fc52e",
+    "entities": [
+      {
+        "tableName": "users",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`user_id` TEXT NOT NULL, `identity_number` TEXT NOT NULL, `relationship` TEXT NOT NULL, `biography` TEXT NOT NULL, `full_name` TEXT, `avatar_url` TEXT, `phone` TEXT, `is_verified` INTEGER, `created_at` TEXT, `mute_until` TEXT, `has_pin` INTEGER, `app_id` TEXT, `is_scam` INTEGER, PRIMARY KEY(`user_id`))",
+        "fields": [
+          {
+            "fieldPath": "userId",
+            "columnName": "user_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityNumber",
+            "columnName": "identity_number",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "relationship",
+            "columnName": "relationship",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "biography",
+            "columnName": "biography",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fullName",
+            "columnName": "full_name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "avatarUrl",
+            "columnName": "avatar_url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "phone",
+            "columnName": "phone",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "isVerified",
+            "columnName": "is_verified",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "muteUntil",
+            "columnName": "mute_until",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "hasPin",
+            "columnName": "has_pin",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "appId",
+            "columnName": "app_id",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "isScam",
+            "columnName": "is_scam",
+            "affinity": "INTEGER",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "user_id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [
+          {
+            "name": "index_users_relationship_full_name",
+            "unique": false,
+            "columnNames": [
+              "relationship",
+              "full_name"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_users_relationship_full_name` ON `${TABLE_NAME}` (`relationship`, `full_name`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "conversations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`conversation_id` TEXT NOT NULL, `owner_id` TEXT, `category` TEXT, `name` TEXT, `icon_url` TEXT, `announcement` TEXT, `code_url` TEXT, `pay_type` TEXT, `created_at` TEXT NOT NULL, `pin_time` TEXT, `last_message_id` TEXT, `last_read_message_id` TEXT, `unseen_message_count` INTEGER, `status` INTEGER NOT NULL, `draft` TEXT, `mute_until` TEXT, `last_message_created_at` TEXT, PRIMARY KEY(`conversation_id`))",
+        "fields": [
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversation_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ownerId",
+            "columnName": "owner_id",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "iconUrl",
+            "columnName": "icon_url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "announcement",
+            "columnName": "announcement",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "codeUrl",
+            "columnName": "code_url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "payType",
+            "columnName": "pay_type",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pinTime",
+            "columnName": "pin_time",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "lastMessageId",
+            "columnName": "last_message_id",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "lastReadMessageId",
+            "columnName": "last_read_message_id",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "unseenMessageCount",
+            "columnName": "unseen_message_count",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "draft",
+            "columnName": "draft",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "muteUntil",
+            "columnName": "mute_until",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "lastMessageCreatedAt",
+            "columnName": "last_message_created_at",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "conversation_id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [
+          {
+            "name": "index_conversations_pin_time_last_message_created_at",
+            "unique": false,
+            "columnNames": [
+              "pin_time",
+              "last_message_created_at"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_conversations_pin_time_last_message_created_at` ON `${TABLE_NAME}` (`pin_time`, `last_message_created_at`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "messages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `conversation_id` TEXT NOT NULL, `user_id` TEXT NOT NULL, `category` TEXT NOT NULL, `content` TEXT, `media_url` TEXT, `media_mime_type` TEXT, `media_size` INTEGER, `media_duration` TEXT, `media_width` INTEGER, `media_height` INTEGER, `media_hash` TEXT, `thumb_image` TEXT, `thumb_url` TEXT, `media_key` BLOB, `media_digest` BLOB, `media_status` TEXT, `status` TEXT NOT NULL, `created_at` TEXT NOT NULL, `action` TEXT, `participant_id` TEXT, `snapshot_id` TEXT, `hyperlink` TEXT, `name` TEXT, `album_id` TEXT, `sticker_id` TEXT, `shared_user_id` TEXT, `media_waveform` BLOB, `media_mine_type` TEXT, `quote_message_id` TEXT, `quote_content` TEXT, `caption` TEXT, PRIMARY KEY(`id`), FOREIGN KEY(`conversation_id`) REFERENCES `conversations`(`conversation_id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversation_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "user_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "mediaUrl",
+            "columnName": "media_url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "mediaMimeType",
+            "columnName": "media_mime_type",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "mediaSize",
+            "columnName": "media_size",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "mediaDuration",
+            "columnName": "media_duration",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "mediaWidth",
+            "columnName": "media_width",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "mediaHeight",
+            "columnName": "media_height",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "mediaHash",
+            "columnName": "media_hash",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "thumbImage",
+            "columnName": "thumb_image",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "thumbUrl",
+            "columnName": "thumb_url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "mediaKey",
+            "columnName": "media_key",
+            "affinity": "BLOB",
+            "notNull": false
+          },
+          {
+            "fieldPath": "mediaDigest",
+            "columnName": "media_digest",
+            "affinity": "BLOB",
+            "notNull": false
+          },
+          {
+            "fieldPath": "mediaStatus",
+            "columnName": "media_status",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "action",
+            "columnName": "action",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "participantId",
+            "columnName": "participant_id",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "snapshotId",
+            "columnName": "snapshot_id",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "hyperlink",
+            "columnName": "hyperlink",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "album_id",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "stickerId",
+            "columnName": "sticker_id",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "sharedUserId",
+            "columnName": "shared_user_id",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "mediaWaveform",
+            "columnName": "media_waveform",
+            "affinity": "BLOB",
+            "notNull": false
+          },
+          {
+            "fieldPath": "mediaMineType",
+            "columnName": "media_mine_type",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "quoteMessageId",
+            "columnName": "quote_message_id",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "quoteContent",
+            "columnName": "quote_content",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "caption",
+            "columnName": "caption",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [
+          {
+            "name": "index_messages_conversation_id_created_at",
+            "unique": false,
+            "columnNames": [
+              "conversation_id",
+              "created_at"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_messages_conversation_id_created_at` ON `${TABLE_NAME}` (`conversation_id`, `created_at`)"
+          },
+          {
+            "name": "index_messages_conversation_id_category",
+            "unique": false,
+            "columnNames": [
+              "conversation_id",
+              "category"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_messages_conversation_id_category` ON `${TABLE_NAME}` (`conversation_id`, `category`)"
+          },
+          {
+            "name": "index_messages_conversation_id_quote_message_id",
+            "unique": false,
+            "columnNames": [
+              "conversation_id",
+              "quote_message_id"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_messages_conversation_id_quote_message_id` ON `${TABLE_NAME}` (`conversation_id`, `quote_message_id`)"
+          },
+          {
+            "name": "index_messages_conversation_id_status_user_id_created_at",
+            "unique": false,
+            "columnNames": [
+              "conversation_id",
+              "status",
+              "user_id",
+              "created_at"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_messages_conversation_id_status_user_id_created_at` ON `${TABLE_NAME}` (`conversation_id`, `status`, `user_id`, `created_at`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "conversations",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "conversation_id"
+            ],
+            "referencedColumns": [
+              "conversation_id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "participants",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`conversation_id` TEXT NOT NULL, `user_id` TEXT NOT NULL, `role` TEXT NOT NULL, `created_at` TEXT NOT NULL, PRIMARY KEY(`conversation_id`, `user_id`), FOREIGN KEY(`conversation_id`) REFERENCES `conversations`(`conversation_id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversation_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "user_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "role",
+            "columnName": "role",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "conversation_id",
+            "user_id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": [
+          {
+            "table": "conversations",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "conversation_id"
+            ],
+            "referencedColumns": [
+              "conversation_id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "participant_session",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`conversation_id` TEXT NOT NULL, `user_id` TEXT NOT NULL, `session_id` TEXT NOT NULL, `sent_to_server` INTEGER, `created_at` TEXT, `public_key` TEXT, PRIMARY KEY(`conversation_id`, `user_id`, `session_id`))",
+        "fields": [
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversation_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "user_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "session_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sentToServer",
+            "columnName": "sent_to_server",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "publicKey",
+            "columnName": "public_key",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "conversation_id",
+            "user_id",
+            "session_id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "offsets",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`key` TEXT NOT NULL, `timestamp` TEXT NOT NULL, PRIMARY KEY(`key`))",
+        "fields": [
+          {
+            "fieldPath": "key",
+            "columnName": "key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "key"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "assets",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`asset_id` TEXT NOT NULL, `symbol` TEXT NOT NULL, `name` TEXT NOT NULL, `icon_url` TEXT NOT NULL, `balance` TEXT NOT NULL, `destination` TEXT NOT NULL, `tag` TEXT, `price_btc` TEXT NOT NULL, `price_usd` TEXT NOT NULL, `chain_id` TEXT NOT NULL, `change_usd` TEXT NOT NULL, `change_btc` TEXT NOT NULL, `confirmations` INTEGER NOT NULL, `asset_key` TEXT, `reserve` TEXT, PRIMARY KEY(`asset_id`))",
+        "fields": [
+          {
+            "fieldPath": "assetId",
+            "columnName": "asset_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "symbol",
+            "columnName": "symbol",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "iconUrl",
+            "columnName": "icon_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "balance",
+            "columnName": "balance",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "destination",
+            "columnName": "destination",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tag",
+            "columnName": "tag",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "priceBtc",
+            "columnName": "price_btc",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "priceUsd",
+            "columnName": "price_usd",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chainId",
+            "columnName": "chain_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "changeUsd",
+            "columnName": "change_usd",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "changeBtc",
+            "columnName": "change_btc",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "confirmations",
+            "columnName": "confirmations",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "assetKey",
+            "columnName": "asset_key",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "reserve",
+            "columnName": "reserve",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "asset_id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "assets_extra",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`asset_id` TEXT NOT NULL, `hidden` INTEGER, PRIMARY KEY(`asset_id`))",
+        "fields": [
+          {
+            "fieldPath": "assetId",
+            "columnName": "asset_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hidden",
+            "columnName": "hidden",
+            "affinity": "INTEGER",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "asset_id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "snapshots",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`snapshot_id` TEXT NOT NULL, `type` TEXT NOT NULL, `asset_id` TEXT NOT NULL, `amount` TEXT NOT NULL, `created_at` TEXT NOT NULL, `opponent_id` TEXT, `trace_id` TEXT, `transaction_hash` TEXT, `sender` TEXT, `receiver` TEXT, `memo` TEXT, `confirmations` INTEGER, PRIMARY KEY(`snapshot_id`))",
+        "fields": [
+          {
+            "fieldPath": "snapshotId",
+            "columnName": "snapshot_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "assetId",
+            "columnName": "asset_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "amount",
+            "columnName": "amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "opponentId",
+            "columnName": "opponent_id",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "traceId",
+            "columnName": "trace_id",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "transactionHash",
+            "columnName": "transaction_hash",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "sender",
+            "columnName": "sender",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "receiver",
+            "columnName": "receiver",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "memo",
+            "columnName": "memo",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "confirmations",
+            "columnName": "confirmations",
+            "affinity": "INTEGER",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "snapshot_id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "messages_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`message_id` TEXT NOT NULL, PRIMARY KEY(`message_id`))",
+        "fields": [
+          {
+            "fieldPath": "messageId",
+            "columnName": "message_id",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "message_id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "sent_sender_keys",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`conversation_id` TEXT NOT NULL, `user_id` TEXT NOT NULL, `sent_to_server` INTEGER NOT NULL, `sender_key_id` INTEGER, `created_at` TEXT, PRIMARY KEY(`conversation_id`, `user_id`))",
+        "fields": [
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversation_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "user_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sentToServer",
+            "columnName": "sent_to_server",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "senderKeyId",
+            "columnName": "sender_key_id",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "conversation_id",
+            "user_id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "stickers",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sticker_id` TEXT NOT NULL, `album_id` TEXT, `name` TEXT NOT NULL, `asset_url` TEXT NOT NULL, `asset_type` TEXT NOT NULL, `asset_width` INTEGER NOT NULL, `asset_height` INTEGER NOT NULL, `created_at` TEXT NOT NULL, `last_use_at` TEXT, PRIMARY KEY(`sticker_id`))",
+        "fields": [
+          {
+            "fieldPath": "stickerId",
+            "columnName": "sticker_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "album_id",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "assetUrl",
+            "columnName": "asset_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "assetType",
+            "columnName": "asset_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "assetWidth",
+            "columnName": "asset_width",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "assetHeight",
+            "columnName": "asset_height",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastUseAt",
+            "columnName": "last_use_at",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "sticker_id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "sticker_albums",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`album_id` TEXT NOT NULL, `name` TEXT NOT NULL, `icon_url` TEXT NOT NULL, `created_at` TEXT NOT NULL, `update_at` TEXT NOT NULL, `user_id` TEXT NOT NULL, `category` TEXT NOT NULL, `description` TEXT NOT NULL, PRIMARY KEY(`album_id`))",
+        "fields": [
+          {
+            "fieldPath": "albumId",
+            "columnName": "album_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "iconUrl",
+            "columnName": "icon_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updateAt",
+            "columnName": "update_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "user_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "album_id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "apps",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`app_id` TEXT NOT NULL, `app_number` TEXT NOT NULL, `home_uri` TEXT NOT NULL, `redirect_uri` TEXT NOT NULL, `name` TEXT NOT NULL, `icon_url` TEXT NOT NULL, `category` TEXT, `description` TEXT NOT NULL, `app_secret` TEXT NOT NULL, `capabilities` TEXT, `creator_id` TEXT NOT NULL, `resource_patterns` TEXT, `updated_at` TEXT, PRIMARY KEY(`app_id`))",
+        "fields": [
+          {
+            "fieldPath": "appId",
+            "columnName": "app_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "appNumber",
+            "columnName": "app_number",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "homeUri",
+            "columnName": "home_uri",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "redirectUri",
+            "columnName": "redirect_uri",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "iconUrl",
+            "columnName": "icon_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "appSecret",
+            "columnName": "app_secret",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "capabilities",
+            "columnName": "capabilities",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "creatorId",
+            "columnName": "creator_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "resourcePatterns",
+            "columnName": "resource_patterns",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "app_id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "hyperlinks",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`hyperlink` TEXT NOT NULL, `site_name` TEXT NOT NULL, `site_title` TEXT NOT NULL, `site_description` TEXT, `site_image` TEXT, PRIMARY KEY(`hyperlink`))",
+        "fields": [
+          {
+            "fieldPath": "hyperlink",
+            "columnName": "hyperlink",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "siteName",
+            "columnName": "site_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "siteTitle",
+            "columnName": "site_title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "siteDescription",
+            "columnName": "site_description",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "siteImage",
+            "columnName": "site_image",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "hyperlink"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "flood_messages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`message_id` TEXT NOT NULL, `data` TEXT NOT NULL, `created_at` TEXT NOT NULL, PRIMARY KEY(`message_id`))",
+        "fields": [
+          {
+            "fieldPath": "messageId",
+            "columnName": "message_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "data",
+            "columnName": "data",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "message_id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "addresses",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`address_id` TEXT NOT NULL, `type` TEXT NOT NULL, `asset_id` TEXT NOT NULL, `destination` TEXT NOT NULL, `label` TEXT NOT NULL, `updated_at` TEXT NOT NULL, `reserve` TEXT NOT NULL, `fee` TEXT NOT NULL, `tag` TEXT, `dust` TEXT, PRIMARY KEY(`address_id`))",
+        "fields": [
+          {
+            "fieldPath": "addressId",
+            "columnName": "address_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "assetId",
+            "columnName": "asset_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "destination",
+            "columnName": "destination",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "label",
+            "columnName": "label",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "reserve",
+            "columnName": "reserve",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fee",
+            "columnName": "fee",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tag",
+            "columnName": "tag",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "dust",
+            "columnName": "dust",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "address_id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "resend_messages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`message_id` TEXT NOT NULL, `user_id` TEXT NOT NULL, `status` INTEGER NOT NULL, `created_at` TEXT NOT NULL, PRIMARY KEY(`message_id`, `user_id`))",
+        "fields": [
+          {
+            "fieldPath": "messageId",
+            "columnName": "message_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "user_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "message_id",
+            "user_id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "resend_session_messages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`message_id` TEXT NOT NULL, `user_id` TEXT NOT NULL, `session_id` TEXT NOT NULL, `status` INTEGER NOT NULL, `created_at` TEXT NOT NULL, PRIMARY KEY(`message_id`, `user_id`, `session_id`))",
+        "fields": [
+          {
+            "fieldPath": "messageId",
+            "columnName": "message_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "user_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "session_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "message_id",
+            "user_id",
+            "session_id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "sticker_relationships",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`album_id` TEXT NOT NULL, `sticker_id` TEXT NOT NULL, PRIMARY KEY(`album_id`, `sticker_id`))",
+        "fields": [
+          {
+            "fieldPath": "albumId",
+            "columnName": "album_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stickerId",
+            "columnName": "sticker_id",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "album_id",
+            "sticker_id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "top_assets",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`asset_id` TEXT NOT NULL, `symbol` TEXT NOT NULL, `name` TEXT NOT NULL, `icon_url` TEXT NOT NULL, `balance` TEXT NOT NULL, `destination` TEXT NOT NULL, `tag` TEXT, `price_btc` TEXT NOT NULL, `price_usd` TEXT NOT NULL, `chain_id` TEXT NOT NULL, `change_usd` TEXT NOT NULL, `change_btc` TEXT NOT NULL, `confirmations` INTEGER NOT NULL, PRIMARY KEY(`asset_id`))",
+        "fields": [
+          {
+            "fieldPath": "assetId",
+            "columnName": "asset_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "symbol",
+            "columnName": "symbol",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "iconUrl",
+            "columnName": "icon_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "balance",
+            "columnName": "balance",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "destination",
+            "columnName": "destination",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tag",
+            "columnName": "tag",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "priceBtc",
+            "columnName": "price_btc",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "priceUsd",
+            "columnName": "price_usd",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chainId",
+            "columnName": "chain_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "changeUsd",
+            "columnName": "change_usd",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "changeBtc",
+            "columnName": "change_btc",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "confirmations",
+            "columnName": "confirmations",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "asset_id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "favorite_apps",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`app_id` TEXT NOT NULL, `user_id` TEXT NOT NULL, `created_at` TEXT NOT NULL, PRIMARY KEY(`app_id`, `user_id`))",
+        "fields": [
+          {
+            "fieldPath": "appId",
+            "columnName": "app_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "user_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "app_id",
+            "user_id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "jobs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`job_id` TEXT NOT NULL, `action` TEXT NOT NULL, `created_at` TEXT NOT NULL, `order_id` INTEGER, `priority` INTEGER NOT NULL, `user_id` TEXT, `blaze_message` TEXT, `conversation_id` TEXT, `resend_message_id` TEXT, `run_count` INTEGER NOT NULL, PRIMARY KEY(`job_id`))",
+        "fields": [
+          {
+            "fieldPath": "jobId",
+            "columnName": "job_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "action",
+            "columnName": "action",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "created_at",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "orderId",
+            "columnName": "order_id",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "priority",
+            "columnName": "priority",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "user_id",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "blazeMessage",
+            "columnName": "blaze_message",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversation_id",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "resendMessageId",
+            "columnName": "resend_message_id",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "runCount",
+            "columnName": "run_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "job_id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [
+          {
+            "name": "index_jobs_action",
+            "unique": false,
+            "columnNames": [
+              "action"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_jobs_action` ON `${TABLE_NAME}` (`action`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "message_mentions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`message_id` TEXT NOT NULL, `conversation_id` TEXT NOT NULL, `mentions` TEXT NOT NULL, `has_read` INTEGER NOT NULL, PRIMARY KEY(`message_id`))",
+        "fields": [
+          {
+            "fieldPath": "messageId",
+            "columnName": "message_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversation_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mentions",
+            "columnName": "mentions",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hasRead",
+            "columnName": "has_read",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "message_id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [
+          {
+            "name": "index_message_mentions_conversation_id",
+            "unique": false,
+            "columnNames": [
+              "conversation_id"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_message_mentions_conversation_id` ON `${TABLE_NAME}` (`conversation_id`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "ftsVersion": "FTS4",
+        "ftsOptions": {
+          "tokenizer": "unicode61",
+          "tokenizerArgs": [],
+          "contentTable": "",
+          "languageIdColumnName": "",
+          "matchInfo": "FTS4",
+          "notIndexedColumns": [
+            "message_id"
+          ],
+          "prefixSizes": [],
+          "preferredOrder": "ASC"
+        },
+        "contentSyncTriggers": [],
+        "tableName": "messages_fts4",
+        "createSql": "CREATE VIRTUAL TABLE IF NOT EXISTS `${TABLE_NAME}` USING FTS4(`message_id` TEXT NOT NULL, `content` TEXT, tokenize=unicode61, notindexed=`message_id`)",
+        "fields": [
+          {
+            "fieldPath": "messageId",
+            "columnName": "message_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "circles",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`circle_id` TEXT NOT NULL, `name` TEXT NOT NULL, `created_at` TEXT NOT NULL, `ordered_at` TEXT, PRIMARY KEY(`circle_id`))",
+        "fields": [
+          {
+            "fieldPath": "circleId",
+            "columnName": "circle_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "orderedAt",
+            "columnName": "ordered_at",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "circle_id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "circle_conversations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`conversation_id` TEXT NOT NULL, `circle_id` TEXT NOT NULL, `user_id` TEXT, `created_at` TEXT NOT NULL, `pin_time` TEXT, PRIMARY KEY(`conversation_id`, `circle_id`))",
+        "fields": [
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversation_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "circleId",
+            "columnName": "circle_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "user_id",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pinTime",
+            "columnName": "pin_time",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "conversation_id",
+            "circle_id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "traces",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`trace_id` TEXT NOT NULL, `asset_id` TEXT NOT NULL, `amount` TEXT NOT NULL, `opponent_id` TEXT, `destination` TEXT, `tag` TEXT, `snapshot_id` TEXT, `created_at` TEXT NOT NULL, PRIMARY KEY(`trace_id`))",
+        "fields": [
+          {
+            "fieldPath": "traceId",
+            "columnName": "trace_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "assetId",
+            "columnName": "asset_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "amount",
+            "columnName": "amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "opponentId",
+            "columnName": "opponent_id",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "destination",
+            "columnName": "destination",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "tag",
+            "columnName": "tag",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "snapshotId",
+            "columnName": "snapshot_id",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "trace_id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "transcript_messages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`transcript_id` TEXT NOT NULL, `message_id` TEXT NOT NULL, `user_id` TEXT, `user_full_name` TEXT, `category` TEXT NOT NULL, `created_at` TEXT NOT NULL, `content` TEXT, `media_url` TEXT, `media_name` TEXT, `media_size` INTEGER, `media_width` INTEGER, `media_height` INTEGER, `media_mime_type` TEXT, `media_duration` INTEGER, `media_status` TEXT, `media_waveform` BLOB, `thumb_image` TEXT, `thumb_url` TEXT, `media_key` BLOB, `media_digest` BLOB, `media_created_at` TEXT, `sticker_id` TEXT, `shared_user_id` TEXT, `mentions` TEXT, `quote_id` TEXT, `quote_content` TEXT, `caption` TEXT, PRIMARY KEY(`transcript_id`, `message_id`))",
+        "fields": [
+          {
+            "fieldPath": "transcriptId",
+            "columnName": "transcript_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "messageId",
+            "columnName": "message_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "user_id",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "userFullName",
+            "columnName": "user_full_name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "mediaUrl",
+            "columnName": "media_url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "mediaName",
+            "columnName": "media_name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "mediaSize",
+            "columnName": "media_size",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "mediaWidth",
+            "columnName": "media_width",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "mediaHeight",
+            "columnName": "media_height",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "mediaMimeType",
+            "columnName": "media_mime_type",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "mediaDuration",
+            "columnName": "media_duration",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "mediaStatus",
+            "columnName": "media_status",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "mediaWaveform",
+            "columnName": "media_waveform",
+            "affinity": "BLOB",
+            "notNull": false
+          },
+          {
+            "fieldPath": "thumbImage",
+            "columnName": "thumb_image",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "thumbUrl",
+            "columnName": "thumb_url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "mediaKey",
+            "columnName": "media_key",
+            "affinity": "BLOB",
+            "notNull": false
+          },
+          {
+            "fieldPath": "mediaDigest",
+            "columnName": "media_digest",
+            "affinity": "BLOB",
+            "notNull": false
+          },
+          {
+            "fieldPath": "mediaCreatedAt",
+            "columnName": "media_created_at",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "stickerId",
+            "columnName": "sticker_id",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "sharedUserId",
+            "columnName": "shared_user_id",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "mentions",
+            "columnName": "mentions",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "quoteId",
+            "columnName": "quote_id",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "quoteContent",
+            "columnName": "quote_content",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "caption",
+            "columnName": "caption",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "transcript_id",
+            "message_id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "pin_messages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`message_id` TEXT NOT NULL, `conversation_id` TEXT NOT NULL, `created_at` TEXT NOT NULL, PRIMARY KEY(`message_id`))",
+        "fields": [
+          {
+            "fieldPath": "messageId",
+            "columnName": "message_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversation_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "message_id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [
+          {
+            "name": "index_pin_messages_conversation_id",
+            "unique": false,
+            "columnNames": [
+              "conversation_id"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_pin_messages_conversation_id` ON `${TABLE_NAME}` (`conversation_id`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "properties",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`key` TEXT NOT NULL, `value` TEXT NOT NULL, `updated_at` TEXT NOT NULL, PRIMARY KEY(`key`))",
+        "fields": [
+          {
+            "fieldPath": "key",
+            "columnName": "key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "value",
+            "columnName": "value",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "key"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '6e545c6d5a47c95c77fdd7150d5fc52e')"
+    ]
+  }
+}

--- a/app/src/main/java/one/mixin/android/Constants.kt
+++ b/app/src/main/java/one/mixin/android/Constants.kt
@@ -79,7 +79,7 @@ object Constants {
     object DataBase {
         const val DB_NAME = "mixin.db"
         const val MINI_VERSION = 15
-        const val CURRENT_VERSION = 39
+        const val CURRENT_VERSION = 40
     }
 
     object Storage {

--- a/app/src/main/java/one/mixin/android/db/MixinDatabase.kt
+++ b/app/src/main/java/one/mixin/android/db/MixinDatabase.kt
@@ -36,7 +36,6 @@ import one.mixin.android.db.MixinDatabaseMigrations.Companion.MIGRATION_32_33
 import one.mixin.android.db.MixinDatabaseMigrations.Companion.MIGRATION_33_34
 import one.mixin.android.db.MixinDatabaseMigrations.Companion.MIGRATION_34_35
 import one.mixin.android.db.MixinDatabaseMigrations.Companion.MIGRATION_35_36
-import one.mixin.android.db.MixinDatabaseMigrations.Companion.MIGRATION_37_38
 import one.mixin.android.db.MixinDatabaseMigrations.Companion.MIGRATION_36_37
 import one.mixin.android.db.MixinDatabaseMigrations.Companion.MIGRATION_37_38
 import one.mixin.android.db.MixinDatabaseMigrations.Companion.MIGRATION_38_39

--- a/app/src/main/java/one/mixin/android/db/MixinDatabase.kt
+++ b/app/src/main/java/one/mixin/android/db/MixinDatabase.kt
@@ -36,9 +36,11 @@ import one.mixin.android.db.MixinDatabaseMigrations.Companion.MIGRATION_32_33
 import one.mixin.android.db.MixinDatabaseMigrations.Companion.MIGRATION_33_34
 import one.mixin.android.db.MixinDatabaseMigrations.Companion.MIGRATION_34_35
 import one.mixin.android.db.MixinDatabaseMigrations.Companion.MIGRATION_35_36
+import one.mixin.android.db.MixinDatabaseMigrations.Companion.MIGRATION_37_38
 import one.mixin.android.db.MixinDatabaseMigrations.Companion.MIGRATION_36_37
 import one.mixin.android.db.MixinDatabaseMigrations.Companion.MIGRATION_37_38
 import one.mixin.android.db.MixinDatabaseMigrations.Companion.MIGRATION_38_39
+import one.mixin.android.db.MixinDatabaseMigrations.Companion.MIGRATION_39_40
 import one.mixin.android.util.GsonHelper
 import one.mixin.android.util.debug.getContent
 import one.mixin.android.util.reportException
@@ -61,6 +63,7 @@ import one.mixin.android.vo.Offset
 import one.mixin.android.vo.Participant
 import one.mixin.android.vo.ParticipantSession
 import one.mixin.android.vo.PinMessage
+import one.mixin.android.vo.Property
 import one.mixin.android.vo.ResendMessage
 import one.mixin.android.vo.ResendSessionMessage
 import one.mixin.android.vo.SentSenderKey
@@ -104,7 +107,8 @@ import one.mixin.android.vo.User
         (CircleConversation::class),
         (Trace::class),
         (TranscriptMessage::class),
-        (PinMessage::class)
+        (PinMessage::class),
+        (Property::class),
     ],
     version = CURRENT_VERSION
 )
@@ -137,6 +141,7 @@ abstract class MixinDatabase : RoomDatabase() {
     abstract fun traceDao(): TraceDao
     abstract fun transcriptDao(): TranscriptMessageDao
     abstract fun pinMessageDao(): PinMessageDao
+    abstract fun propertyDao(): PropertyDao
 
     companion object {
         private var INSTANCE: MixinDatabase? = null
@@ -165,7 +170,7 @@ abstract class MixinDatabase : RoomDatabase() {
                             MIGRATION_15_16, MIGRATION_16_17, MIGRATION_17_18, MIGRATION_18_19, MIGRATION_19_20, MIGRATION_20_21, MIGRATION_21_22,
                             MIGRATION_22_23, MIGRATION_23_24, MIGRATION_24_25, MIGRATION_25_26, MIGRATION_26_27, MIGRATION_27_28, MIGRATION_28_29,
                             MIGRATION_29_30, MIGRATION_30_31, MIGRATION_31_32, MIGRATION_32_33, MIGRATION_33_34, MIGRATION_34_35, MIGRATION_35_36,
-                            MIGRATION_36_37, MIGRATION_37_38, MIGRATION_38_39
+                            MIGRATION_36_37, MIGRATION_37_38, MIGRATION_38_39, MIGRATION_39_40
                         )
                         .enableMultiInstanceInvalidation()
                         .addCallback(CALLBACK)

--- a/app/src/main/java/one/mixin/android/db/MixinDatabaseMigrations.kt
+++ b/app/src/main/java/one/mixin/android/db/MixinDatabaseMigrations.kt
@@ -279,7 +279,12 @@ class MixinDatabaseMigrations private constructor() {
                 database.execSQL("CREATE INDEX IF NOT EXISTS `index_pin_messages_conversation_id` ON `pin_messages` (`conversation_id`)")
                 database.execSQL("DROP INDEX IF EXISTS `index_messages_conversation_id_user_id_status_created_at`")
                 database.execSQL("DROP INDEX IF EXISTS `index_messages_conversation_id_status_user_id`")
-                database.execSQL("CREATE INDEX IF NOT EXISTS `index_messages_conversation_id_status_user_id_created_at` ON `messages` (`conversation_id`, `status`,`user_id`, `created_at`)")
+            }
+        }
+
+        val MIGRATION_39_40: Migration = object : Migration(39, 40) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL("CREATE TABLE IF NOT EXISTS `properties` (`key` TEXT NOT NULL, `value` TEXT NOT NULL, `updated_at` TEXT NOT NULL, PRIMARY KEY(`key`))")
             }
         }
     }

--- a/app/src/main/java/one/mixin/android/db/PropertyDao.kt
+++ b/app/src/main/java/one/mixin/android/db/PropertyDao.kt
@@ -1,0 +1,19 @@
+package one.mixin.android.db
+
+import androidx.room.Dao
+import androidx.room.Query
+import one.mixin.android.extension.nowInUtc
+import one.mixin.android.vo.Property
+
+@Dao
+interface PropertyDao : BaseDao<Property> {
+
+    @Query("SELECT * FROM properties WHERE `key` = :key")
+    suspend fun findByKey(key: String): Property?
+
+    @Query("SELECT value FROM properties WHERE `key` = :key")
+    suspend fun findValueByKey(key: String): String?
+
+    @Query("UPDATE properties SET value = :value, updated_at = :updatedAt WHERE `key` = :key")
+    suspend fun updateValueByKey(key: String, value: String, updatedAt: String = nowInUtc())
+}

--- a/app/src/main/java/one/mixin/android/di/BaseDbModule.kt
+++ b/app/src/main/java/one/mixin/android/di/BaseDbModule.kt
@@ -136,4 +136,8 @@ internal object BaseDbModule {
     @Singleton
     @Provides
     fun providesPinMessageDao(db: MixinDatabase) = db.pinMessageDao()
+
+    @Singleton
+    @Provides
+    fun providesPropertyDao(db: MixinDatabase) = db.propertyDao()
 }

--- a/app/src/main/java/one/mixin/android/extension/NetWorkExtension.kt
+++ b/app/src/main/java/one/mixin/android/extension/NetWorkExtension.kt
@@ -9,15 +9,16 @@ import one.mixin.android.Constants
 import one.mixin.android.Constants.Download.MOBILE_DEFAULT
 import one.mixin.android.Constants.Download.ROAMING_DEFAULT
 import one.mixin.android.Constants.Download.WIFI_DEFAULT
+import one.mixin.android.util.PropertyHelper
 import timber.log.Timber
 
-val autoDownloadPhoto: (value: Int) -> Boolean = {
+val autoDownloadPhoto: suspend (value: Int) -> Boolean = {
     it.or(0x110) == 0x111
 }
-val autoDownloadVideo: (value: Int) -> Boolean = {
+val autoDownloadVideo: suspend (value: Int) -> Boolean = {
     it.or(0x101) == 0x111
 }
-val autoDownloadDocument: (value: Int) -> Boolean = {
+val autoDownloadDocument: suspend (value: Int) -> Boolean = {
     it.or(0x011) == 0x111
 }
 
@@ -49,7 +50,7 @@ fun Context.isRoaming(): Boolean {
     return false
 }
 
-fun Context.differentNetWorkAction(wifiAction: () -> Unit, mobileAction: () -> Unit, roaming: () -> Unit) {
+suspend fun Context.differentNetWorkAction(wifiAction: suspend () -> Unit, mobileAction: suspend () -> Unit, roaming: suspend () -> Unit) {
     when {
         isConnectedToWiFi() -> {
             wifiAction()
@@ -63,7 +64,7 @@ fun Context.differentNetWorkAction(wifiAction: () -> Unit, mobileAction: () -> U
     }
 }
 
-fun Context.autoDownload(support: (value: Int) -> Boolean, action: () -> Unit) {
+suspend fun Context.autoDownload(support: suspend (value: Int) -> Boolean, action: () -> Unit) {
     if (hasWritePermission()) {
         differentNetWorkAction(
             {
@@ -85,6 +86,6 @@ fun Context.autoDownload(support: (value: Int) -> Boolean, action: () -> Unit) {
     }
 }
 
-fun Context.getAutoDownloadWifiValue() = defaultSharedPreferences.getInt(Constants.Download.AUTO_DOWNLOAD_WIFI, WIFI_DEFAULT)
-fun Context.getAutoDownloadMobileValue() = defaultSharedPreferences.getInt(Constants.Download.AUTO_DOWNLOAD_MOBILE, MOBILE_DEFAULT)
-fun Context.getAutoDownloadRoamingValue() = defaultSharedPreferences.getInt(Constants.Download.AUTO_DOWNLOAD_ROAMING, ROAMING_DEFAULT)
+suspend fun Context.getAutoDownloadWifiValue() = PropertyHelper.findValueByKey(this, Constants.Download.AUTO_DOWNLOAD_WIFI)?.toIntOrNull() ?: WIFI_DEFAULT
+suspend fun Context.getAutoDownloadMobileValue() = PropertyHelper.findValueByKey(this, Constants.Download.AUTO_DOWNLOAD_MOBILE)?.toIntOrNull() ?: MOBILE_DEFAULT
+suspend fun Context.getAutoDownloadRoamingValue() = PropertyHelper.findValueByKey(this, Constants.Download.AUTO_DOWNLOAD_ROAMING)?.toIntOrNull() ?: ROAMING_DEFAULT

--- a/app/src/main/java/one/mixin/android/job/AttachmentMigrationJob.kt
+++ b/app/src/main/java/one/mixin/android/job/AttachmentMigrationJob.kt
@@ -2,7 +2,8 @@ package one.mixin.android.job
 
 import androidx.core.net.toUri
 import com.birbit.android.jobqueue.Params
-import one.mixin.android.Constants
+import kotlinx.coroutines.runBlocking
+import one.mixin.android.Constants.Account.PREF_ATTACHMENT
 import one.mixin.android.Constants.Account.PREF_ATTACHMENT_LAST
 import one.mixin.android.Constants.Account.PREF_ATTACHMENT_OFFSET
 import one.mixin.android.MixinApplication
@@ -13,7 +14,6 @@ import one.mixin.android.extension.createGifTemp
 import one.mixin.android.extension.createImageTemp
 import one.mixin.android.extension.createVideoTemp
 import one.mixin.android.extension.createWebpTemp
-import one.mixin.android.extension.defaultSharedPreferences
 import one.mixin.android.extension.getAudioPath
 import one.mixin.android.extension.getDocumentPath
 import one.mixin.android.extension.getExtensionName
@@ -23,8 +23,6 @@ import one.mixin.android.extension.getOldMediaPath
 import one.mixin.android.extension.getVideoPath
 import one.mixin.android.extension.hasWritePermission
 import one.mixin.android.extension.isImageSupport
-import one.mixin.android.extension.putBoolean
-import one.mixin.android.extension.putLong
 import one.mixin.android.vo.MessageCategory
 import one.mixin.android.widget.gallery.MimeType
 import timber.log.Timber
@@ -36,16 +34,15 @@ class AttachmentMigrationJob : BaseJob(Params(PRIORITY_LOWER).groupBy(GROUP_ID).
         private const val EACH = 10
     }
 
-    override fun onRun() {
+    override fun onRun() = runBlocking {
         val startTime = System.currentTimeMillis()
-        val preferences = MixinApplication.appContext.defaultSharedPreferences
-        var migrationLast = preferences.getLong(PREF_ATTACHMENT_LAST, -1)
-        val offset = preferences.getLong(PREF_ATTACHMENT_OFFSET, 0)
+        var migrationLast = propertyDao.findValueByKey(PREF_ATTACHMENT_LAST)?.toLongOrNull() ?: -1
+        val offset = propertyDao.findValueByKey(PREF_ATTACHMENT_OFFSET)?.toLongOrNull() ?: 0
         if (migrationLast == -1L) {
             migrationLast = messageDao.getLastMessageRowid()
-            preferences.putLong(PREF_ATTACHMENT_LAST, migrationLast)
+            propertyDao.updateValueByKey(PREF_ATTACHMENT_LAST, migrationLast.toString())
         }
-        if (!hasWritePermission()) return
+        if (!hasWritePermission()) return@runBlocking
         val list = messageDao.findAttachmentMigration(migrationLast, EACH, offset)
         list.forEach { attachment ->
             val path = attachment.mediaUrl?.toUri()?.getFilePath() ?: return@forEach
@@ -93,11 +90,11 @@ class AttachmentMigrationJob : BaseJob(Params(PRIORITY_LOWER).groupBy(GROUP_ID).
             fromFile.renameTo(toFile)
             messageDao.updateMediaMessageUrl(toFile.name, attachment.messageId)
         }
-        preferences.putLong(PREF_ATTACHMENT_OFFSET, offset + list.size)
+        propertyDao.updateValueByKey(PREF_ATTACHMENT_OFFSET, (offset + list.size).toString())
         Timber.d("Attachment migration handle ${offset + list.size} file cost: ${System.currentTimeMillis() - startTime} ms")
         if (list.size < EACH) {
             MixinApplication.appContext.getOldMediaPath()?.deleteRecursively()
-            preferences.putBoolean(Constants.Account.PREF_ATTACHMENT, true)
+            propertyDao.updateValueByKey(PREF_ATTACHMENT, true.toString())
         } else {
             jobManager.addJobInBackground(AttachmentMigrationJob())
         }

--- a/app/src/main/java/one/mixin/android/job/BackupMigrationJob.kt
+++ b/app/src/main/java/one/mixin/android/job/BackupMigrationJob.kt
@@ -1,13 +1,13 @@
 package one.mixin.android.job
 
 import com.birbit.android.jobqueue.Params
+import kotlinx.coroutines.runBlocking
 import one.mixin.android.Constants
 import one.mixin.android.Constants.Account.PREF_BACKUP
 import one.mixin.android.MixinApplication
-import one.mixin.android.extension.defaultSharedPreferences
 import one.mixin.android.extension.getBackupPath
 import one.mixin.android.extension.hasWritePermission
-import one.mixin.android.extension.putBoolean
+import one.mixin.android.util.PropertyHelper
 import one.mixin.android.util.backup.findOldBackupSync
 import timber.log.Timber
 import java.io.File
@@ -17,18 +17,18 @@ class BackupMigrationJob : BaseJob(Params(PRIORITY_LOWER).groupBy(GROUP_ID).pers
         private const val GROUP_ID = "backup_migration"
     }
 
-    override fun onRun() {
+    override fun onRun() = runBlocking {
         val startTime = System.currentTimeMillis()
-        val preferences = MixinApplication.appContext.defaultSharedPreferences
-        if (!hasWritePermission()) return
-        if (!preferences.getBoolean(PREF_BACKUP, false)) {
+        if (!hasWritePermission()) return@runBlocking
+
+        if (propertyDao.findValueByKey(PREF_BACKUP)?.toBoolean() != true) {
             val oldBackup = findOldBackupSync(MixinApplication.appContext)
             if (oldBackup != null && oldBackup.exists()) {
                 MixinApplication.get().getBackupPath(true)?.let { backupDir ->
                     oldBackup.renameTo(File("$backupDir${File.separator}${Constants.DataBase.DB_NAME}"))
                 }
             }
-            preferences.putBoolean(PREF_BACKUP, true)
+            PropertyHelper.updateKeyValue(MixinApplication.appContext, PREF_BACKUP, true.toString())
         }
         Timber.d("Backup migration cost: ${System.currentTimeMillis() - startTime} ms")
     }

--- a/app/src/main/java/one/mixin/android/job/BaseJob.kt
+++ b/app/src/main/java/one/mixin/android/job/BaseJob.kt
@@ -45,6 +45,7 @@ import one.mixin.android.db.OffsetDao
 import one.mixin.android.db.ParticipantDao
 import one.mixin.android.db.ParticipantSessionDao
 import one.mixin.android.db.PinMessageDao
+import one.mixin.android.db.PropertyDao
 import one.mixin.android.db.SnapshotDao
 import one.mixin.android.db.StickerAlbumDao
 import one.mixin.android.db.StickerDao
@@ -186,6 +187,9 @@ abstract class BaseJob(params: Params) : Job(params) {
     @Inject
     @Transient
     lateinit var pinMessageDao: PinMessageDao
+    @Inject
+    @Transient
+    lateinit var propertyDao: PropertyDao
     @Inject
     @Transient
     lateinit var signalProtocol: SignalProtocol

--- a/app/src/main/java/one/mixin/android/job/DecryptMessage.kt
+++ b/app/src/main/java/one/mixin/android/job/DecryptMessage.kt
@@ -786,9 +786,39 @@ class DecryptMessage(private val lifecycleScope: CoroutineScope) : Injector() {
             transcript.mediaSize?.let {
                 mediaSize += it
             }
-            when {
-                transcript.isImage() -> {
-                    MixinApplication.appContext.autoDownload(autoDownloadPhoto) {
+            lifecycleScope.launch {
+                when {
+                    transcript.isImage() -> {
+                        MixinApplication.appContext.autoDownload(autoDownloadPhoto) {
+                            jobManager.addJobInBackground(
+                                TranscriptAttachmentDownloadJob(
+                                    data.conversationId,
+                                    transcript
+                                )
+                            )
+                        }
+                    }
+                    transcript.isVideo() -> {
+                        MixinApplication.appContext.autoDownload(autoDownloadVideo) {
+                            jobManager.addJobInBackground(
+                                TranscriptAttachmentDownloadJob(
+                                    data.conversationId,
+                                    transcript
+                                )
+                            )
+                        }
+                    }
+                    transcript.isData() -> {
+                        MixinApplication.appContext.autoDownload(autoDownloadDocument) {
+                            jobManager.addJobInBackground(
+                                TranscriptAttachmentDownloadJob(
+                                    data.conversationId,
+                                    transcript
+                                )
+                            )
+                        }
+                    }
+                    transcript.isAudio() -> {
                         jobManager.addJobInBackground(
                             TranscriptAttachmentDownloadJob(
                                 data.conversationId,
@@ -796,34 +826,6 @@ class DecryptMessage(private val lifecycleScope: CoroutineScope) : Injector() {
                             )
                         )
                     }
-                }
-                transcript.isVideo() -> {
-                    MixinApplication.appContext.autoDownload(autoDownloadVideo) {
-                        jobManager.addJobInBackground(
-                            TranscriptAttachmentDownloadJob(
-                                data.conversationId,
-                                transcript
-                            )
-                        )
-                    }
-                }
-                transcript.isData() -> {
-                    MixinApplication.appContext.autoDownload(autoDownloadDocument) {
-                        jobManager.addJobInBackground(
-                            TranscriptAttachmentDownloadJob(
-                                data.conversationId,
-                                transcript
-                            )
-                        )
-                    }
-                }
-                transcript.isAudio() -> {
-                    jobManager.addJobInBackground(
-                        TranscriptAttachmentDownloadJob(
-                            data.conversationId,
-                            transcript
-                        )
-                    )
                 }
             }
         }

--- a/app/src/main/java/one/mixin/android/job/DecryptMessage.kt
+++ b/app/src/main/java/one/mixin/android/job/DecryptMessage.kt
@@ -7,6 +7,7 @@ import androidx.collection.arrayMapOf
 import com.bugsnag.android.Bugsnag
 import com.google.firebase.crashlytics.FirebaseCrashlytics
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import one.mixin.android.Constants
 import one.mixin.android.MixinApplication
@@ -592,8 +593,10 @@ class DecryptMessage(private val lifecycleScope: CoroutineScope) : Injector() {
                 }
 
                 messageDao.insertAndNotifyConversation(message, conversationDao, accountId)
-                MixinApplication.appContext.autoDownload(autoDownloadPhoto) {
-                    jobManager.addJobInBackground(AttachmentDownloadJob(message))
+                lifecycleScope.launch {
+                    MixinApplication.appContext.autoDownload(autoDownloadPhoto) {
+                        jobManager.addJobInBackground(AttachmentDownloadJob(message))
+                    }
                 }
 
                 generateNotification(message, data)
@@ -617,8 +620,10 @@ class DecryptMessage(private val lifecycleScope: CoroutineScope) : Injector() {
                 }
 
                 messageDao.insertAndNotifyConversation(message, conversationDao, accountId)
-                MixinApplication.appContext.autoDownload(autoDownloadVideo) {
-                    jobManager.addJobInBackground(AttachmentDownloadJob(message))
+                lifecycleScope.launch {
+                    MixinApplication.appContext.autoDownload(autoDownloadVideo) {
+                        jobManager.addJobInBackground(AttachmentDownloadJob(message))
+                    }
                 }
                 generateNotification(message, data)
             }
@@ -637,8 +642,10 @@ class DecryptMessage(private val lifecycleScope: CoroutineScope) : Injector() {
 
                 messageDao.insertAndNotifyConversation(message, conversationDao, accountId)
                 MessageFts4Helper.insertOrReplaceMessageFts4(message)
-                MixinApplication.appContext.autoDownload(autoDownloadDocument) {
-                    jobManager.addJobInBackground(AttachmentDownloadJob(message))
+                lifecycleScope.launch {
+                    MixinApplication.appContext.autoDownload(autoDownloadDocument) {
+                        jobManager.addJobInBackground(AttachmentDownloadJob(message))
+                    }
                 }
                 generateNotification(message, data)
             }

--- a/app/src/main/java/one/mixin/android/ui/home/MainActivity.kt
+++ b/app/src/main/java/one/mixin/android/ui/home/MainActivity.kt
@@ -42,8 +42,6 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import one.mixin.android.BuildConfig
 import one.mixin.android.Constants
-import one.mixin.android.Constants.Account.PREF_ATTACHMENT
-import one.mixin.android.Constants.Account.PREF_BACKUP
 import one.mixin.android.Constants.Account.PREF_BATTERY_OPTIMIZE
 import one.mixin.android.Constants.Account.PREF_CHECK_STORAGE
 import one.mixin.android.Constants.Account.PREF_SYNC_CIRCLE
@@ -122,6 +120,7 @@ import one.mixin.android.ui.search.SearchSingleFragment
 import one.mixin.android.util.BiometricUtil
 import one.mixin.android.util.ErrorHandler
 import one.mixin.android.util.ErrorHandler.Companion.errorHandler
+import one.mixin.android.util.PropertyHelper
 import one.mixin.android.util.RootUtil
 import one.mixin.android.vo.Conversation
 import one.mixin.android.vo.ConversationCategory
@@ -246,11 +245,6 @@ class MainActivity : BlazeBaseActivity() {
             return
         }
 
-        if (defaultSharedPreferences.getInt(PREF_LOGIN_FROM, FROM_LOGIN) == FROM_EMERGENCY) {
-            defaultSharedPreferences.putInt(PREF_LOGIN_FROM, FROM_LOGIN)
-            delayShowModifyMobile()
-        }
-
         binding = ActivityMainBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
@@ -265,43 +259,10 @@ class MainActivity : BlazeBaseActivity() {
             AppCenter.setUserId(it.userId)
         }
 
-        if (!defaultSharedPreferences.getBoolean(PREF_SYNC_CIRCLE, false)) {
-            jobManager.addJobInBackground(RefreshCircleJob())
-            defaultSharedPreferences.putBoolean(PREF_SYNC_CIRCLE, true)
-        }
-        jobManager.addJobInBackground(RefreshOneTimePreKeysJob())
-        jobManager.addJobInBackground(BackupJob())
-        if (!defaultSharedPreferences.getBoolean(PREF_ATTACHMENT, false)) {
-            jobManager.addJobInBackground(AttachmentMigrationJob())
-        }
-
-        if (!defaultSharedPreferences.getBoolean(PREF_BACKUP, false)) {
-            jobManager.addJobInBackground(BackupMigrationJob())
-        }
-
-        lifecycleScope.launch(Dispatchers.IO) {
-            jobManager.addJobInBackground(RefreshAccountJob())
-
-            if (Fiats.isRateEmpty()) {
-                jobManager.addJobInBackground(RefreshFiatsJob())
-            }
-
-            WorkManager.getInstance(this@MainActivity)
-                .enqueueUniqueOneTimeNetworkWorkRequest<RefreshContactWorker>("RefreshContactWorker")
-            WorkManager.getInstance(this@MainActivity)
-                .enqueueUniqueOneTimeNetworkWorkRequest<RefreshFcmWorker>("RefreshFcmWorker")
-            WorkManager.getInstance(this@MainActivity).pruneWork()
-        }
-        checkRoot()
-        checkUpdate()
-        checkStorage()
-
         initView()
         handlerCode(intent)
 
-        sendSafetyNetRequest()
-        checkBatteryOptimization()
-        refreshStickerAlbum()
+        checkAsync()
     }
 
     override fun onStart() {
@@ -312,6 +273,52 @@ class MainActivity : BlazeBaseActivity() {
     override fun onDestroy() {
         super.onDestroy()
         appUpdateManager.unregisterListener(updatedListener)
+    }
+
+    private fun checkAsync() = lifecycleScope.launch(Dispatchers.IO) {
+        checkRoot()
+        checkUpdate()
+        checkStorage()
+        sendSafetyNetRequest()
+        checkBatteryOptimization()
+        refreshStickerAlbum()
+
+        if (!defaultSharedPreferences.getBoolean(PREF_SYNC_CIRCLE, false)) {
+            jobManager.addJobInBackground(RefreshCircleJob())
+            defaultSharedPreferences.putBoolean(PREF_SYNC_CIRCLE, true)
+        }
+
+        jobManager.addJobInBackground(RefreshOneTimePreKeysJob())
+        jobManager.addJobInBackground(BackupJob())
+        jobManager.addJobInBackground(RefreshAccountJob())
+
+        if (defaultSharedPreferences.getInt(PREF_LOGIN_FROM, FROM_LOGIN) == FROM_EMERGENCY) {
+            defaultSharedPreferences.putInt(PREF_LOGIN_FROM, FROM_LOGIN)
+            delayShowModifyMobile()
+        }
+
+        if (Fiats.isRateEmpty()) {
+            jobManager.addJobInBackground(RefreshFiatsJob())
+        }
+
+        PropertyHelper.checkFts4Upgrade(this@MainActivity) {
+            InitializeActivity.showFts(this@MainActivity)
+            finish()
+        }
+
+        PropertyHelper.checkAttachmentMigrated(this@MainActivity) {
+            jobManager.addJobInBackground(AttachmentMigrationJob())
+        }
+
+        PropertyHelper.checkBackupMigrated(this@MainActivity) {
+            jobManager.addJobInBackground(BackupMigrationJob())
+        }
+
+        WorkManager.getInstance(this@MainActivity)
+            .enqueueUniqueOneTimeNetworkWorkRequest<RefreshContactWorker>("RefreshContactWorker")
+        WorkManager.getInstance(this@MainActivity)
+            .enqueueUniqueOneTimeNetworkWorkRequest<RefreshFcmWorker>("RefreshFcmWorker")
+        WorkManager.getInstance(this@MainActivity).pruneWork()
     }
 
     @SuppressLint("RestrictedApi")

--- a/app/src/main/java/one/mixin/android/ui/home/MainActivity.kt
+++ b/app/src/main/java/one/mixin/android/ui/home/MainActivity.kt
@@ -219,12 +219,6 @@ class MainActivity : BlazeBaseActivity() {
             return
         }
 
-        if (!defaultSharedPreferences.getBoolean(Constants.Account.PREF_FTS4_UPGRADE, false)) {
-            InitializeActivity.showFts(this)
-            finish()
-            return
-        }
-
         if (checkNeedGo2MigrationPage()) {
             InitializeActivity.showDBUpgrade(this)
             finish()

--- a/app/src/main/java/one/mixin/android/ui/landing/UpgradeFragment.kt
+++ b/app/src/main/java/one/mixin/android/ui/landing/UpgradeFragment.kt
@@ -14,12 +14,11 @@ import one.mixin.android.MixinApplication
 import one.mixin.android.R
 import one.mixin.android.databinding.FragmentUpgradeBinding
 import one.mixin.android.db.runInTransaction
-import one.mixin.android.extension.defaultSharedPreferences
-import one.mixin.android.extension.putBoolean
 import one.mixin.android.extension.withArgs
 import one.mixin.android.ui.common.BaseFragment
 import one.mixin.android.ui.home.MainActivity
 import one.mixin.android.util.MessageFts4Helper
+import one.mixin.android.util.PropertyHelper
 import one.mixin.android.util.viewBinding
 
 @AndroidEntryPoint
@@ -55,7 +54,7 @@ class UpgradeFragment : BaseFragment(R.layout.fragment_upgrade) {
                 if (!done) {
                     viewModel.startSyncFts4Job()
                 }
-                defaultSharedPreferences.putBoolean(PREF_FTS4_UPGRADE, true)
+                PropertyHelper.updateKeyValue(requireContext(), PREF_FTS4_UPGRADE, true.toString())
                 MainActivity.show(requireContext())
                 activity?.finish()
             }
@@ -63,6 +62,7 @@ class UpgradeFragment : BaseFragment(R.layout.fragment_upgrade) {
             lifecycleScope.launch {
                 binding.pb.isIndeterminate = true
                 withContext(Dispatchers.IO) {
+                    PropertyHelper.checkMigrated(requireContext())
                     runInTransaction { }
                 }
                 MainActivity.show(requireContext())

--- a/app/src/main/java/one/mixin/android/ui/setting/NotificationsFragment.kt
+++ b/app/src/main/java/one/mixin/android/ui/setting/NotificationsFragment.kt
@@ -15,10 +15,8 @@ import one.mixin.android.R
 import one.mixin.android.api.handleMixinResponse
 import one.mixin.android.api.request.AccountUpdateRequest
 import one.mixin.android.databinding.FragmentNotificationsBinding
-import one.mixin.android.extension.defaultSharedPreferences
 import one.mixin.android.extension.indeterminateProgressDialog
 import one.mixin.android.extension.openNotificationSetting
-import one.mixin.android.extension.putBoolean
 import one.mixin.android.extension.supportsOreo
 import one.mixin.android.extension.toast
 import one.mixin.android.extension.viewDestroyed
@@ -26,6 +24,7 @@ import one.mixin.android.session.Session
 import one.mixin.android.ui.common.BaseFragment
 import one.mixin.android.ui.common.editDialog
 import one.mixin.android.util.ChannelManager
+import one.mixin.android.util.PropertyHelper
 import one.mixin.android.util.viewBinding
 import one.mixin.android.vo.Fiats
 
@@ -60,14 +59,16 @@ class NotificationsFragment : BaseFragment(R.layout.fragment_notifications) {
             }
             refreshLargeAmount(Session.getAccount()!!.transferConfirmationThreshold)
 
-            duplicateTransferSc.isChecked = defaultSharedPreferences.getBoolean(PREF_DUPLICATE_TRANSFER, true)
+            lifecycleScope.launch {
+                duplicateTransferSc.isChecked = PropertyHelper.findValueByKey(requireContext(), PREF_DUPLICATE_TRANSFER)?.toBoolean() ?: true
+                strangerTransferSc.isChecked = PropertyHelper.findValueByKey(requireContext(), PREF_STRANGER_TRANSFER)?.toBoolean() ?: true
+            }
             duplicateTransferSc.setOnCheckedChangeListener { _, isChecked ->
-                defaultSharedPreferences.putBoolean(PREF_DUPLICATE_TRANSFER, isChecked)
+                updateKeyValue(PREF_DUPLICATE_TRANSFER, isChecked.toString())
             }
 
-            strangerTransferSc.isChecked = defaultSharedPreferences.getBoolean(PREF_STRANGER_TRANSFER, true)
             strangerTransferSc.setOnCheckedChangeListener { _, isChecked ->
-                defaultSharedPreferences.putBoolean(PREF_STRANGER_TRANSFER, isChecked)
+                updateKeyValue(PREF_STRANGER_TRANSFER, isChecked.toString())
             }
 
             supportsOreo {
@@ -78,6 +79,10 @@ class NotificationsFragment : BaseFragment(R.layout.fragment_notifications) {
                 }
             }
         }
+    }
+
+    private fun updateKeyValue(key: String, value: String) = lifecycleScope.launch {
+        PropertyHelper.updateKeyValue(requireContext(), key, value)
     }
 
     @SuppressLint("RestrictedApi")

--- a/app/src/main/java/one/mixin/android/ui/setting/SettingDataStorageFragment.kt
+++ b/app/src/main/java/one/mixin/android/ui/setting/SettingDataStorageFragment.kt
@@ -5,7 +5,9 @@ import android.view.View
 import android.view.WindowManager
 import androidx.annotation.StringRes
 import androidx.appcompat.app.AlertDialog
+import androidx.lifecycle.lifecycleScope
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
 import one.mixin.android.Constants.Download.AUTO_DOWNLOAD_DOCUMENT
 import one.mixin.android.Constants.Download.AUTO_DOWNLOAD_MOBILE
 import one.mixin.android.Constants.Download.AUTO_DOWNLOAD_PHOTO
@@ -52,22 +54,30 @@ class SettingDataStorageFragment : BaseFragment(R.layout.fragment_storage_data) 
                     SettingStorageFragment.TAG
                 )
             }
-            storageMobile.setOnClickListener { showMenu(AUTO_DOWNLOAD_MOBILE, requireContext().getAutoDownloadMobileValue(), R.string.setting_data_mobile) }
+            storageMobile.setOnClickListener {
+                lifecycleScope.launch {
+                    showMenu(AUTO_DOWNLOAD_MOBILE, requireContext().getAutoDownloadMobileValue(), R.string.setting_data_mobile)
+                }
+            }
             storageWifi.setOnClickListener {
-                showMenu(
-                    AUTO_DOWNLOAD_WIFI,
-                    requireContext().getAutoDownloadWifiValue(),
-                    R.string
-                        .setting_data_wifi
-                )
+                lifecycleScope.launch {
+                    showMenu(
+                        AUTO_DOWNLOAD_WIFI,
+                        requireContext().getAutoDownloadWifiValue(),
+                        R.string
+                            .setting_data_wifi
+                    )
+                }
             }
             storageRoaming.setOnClickListener {
-                showMenu(
-                    AUTO_DOWNLOAD_ROAMING,
-                    requireContext().getAutoDownloadRoamingValue(),
-                    R.string
-                        .setting_data_roaming
-                )
+                lifecycleScope.launch {
+                    showMenu(
+                        AUTO_DOWNLOAD_ROAMING,
+                        requireContext().getAutoDownloadRoamingValue(),
+                        R.string
+                            .setting_data_roaming
+                    )
+                }
             }
         }
     }
@@ -77,7 +87,7 @@ class SettingDataStorageFragment : BaseFragment(R.layout.fragment_storage_data) 
         refresh()
     }
 
-    private fun refresh() {
+    private fun refresh() = lifecycleScope.launch {
         binding.apply {
             storageMobileInfo.text = getInfo(requireContext().getAutoDownloadMobileValue())
             storageWifiInfo.text = getInfo(requireContext().getAutoDownloadWifiValue())
@@ -85,7 +95,7 @@ class SettingDataStorageFragment : BaseFragment(R.layout.fragment_storage_data) 
         }
     }
 
-    private fun getInfo(value: Int): String {
+    private suspend fun getInfo(value: Int): String {
         val list = mutableListOf<String>()
         if (autoDownloadPhoto(value)) list.add(getString(R.string.setting_data_photo))
         if (autoDownloadVideo(value)) list.add(getString(R.string.setting_data_video))
@@ -103,7 +113,7 @@ class SettingDataStorageFragment : BaseFragment(R.layout.fragment_storage_data) 
     }
 
     private var menuDialog: AlertDialog? = null
-    private fun showMenu(key: String, value: Int, @StringRes titleId: Int) {
+    private suspend fun showMenu(key: String, value: Int, @StringRes titleId: Int) {
         menuDialog?.dismiss()
         val menuBinding = ViewStotageDataBinding.inflate(requireContext().layoutInflater, null, false).apply {
             this.checkPhoto.apply {

--- a/app/src/main/java/one/mixin/android/util/MessageFts4Helper.kt
+++ b/app/src/main/java/one/mixin/android/util/MessageFts4Helper.kt
@@ -6,9 +6,7 @@ import androidx.room.ColumnInfo
 import one.mixin.android.Constants.Account.PREF_SYNC_FTS4_OFFSET
 import one.mixin.android.MixinApplication
 import one.mixin.android.db.MixinDatabase
-import one.mixin.android.extension.defaultSharedPreferences
 import one.mixin.android.extension.joinWhiteSpace
-import one.mixin.android.extension.putInt
 import one.mixin.android.vo.Message
 import one.mixin.android.vo.MessageFts4
 import one.mixin.android.vo.isContact
@@ -40,7 +38,7 @@ object MessageFts4Helper {
         val messageFts4Dao = MixinDatabase.getDatabase(ctx).messageFts4Dao()
 
         var done = false
-        var offset = ctx.defaultSharedPreferences.getInt(PREF_SYNC_FTS4_OFFSET, 0)
+        var offset = PropertyHelper.findValueByKey(ctx, PREF_SYNC_FTS4_OFFSET)?.toIntOrNull() ?: 0
         var handleCount = 0
         var start: Long
         val totalStart = System.currentTimeMillis()
@@ -58,7 +56,7 @@ object MessageFts4Helper {
             messageFts4Dao.insertListSuspend(messageFts4List)
             offset += queryMessageList.size
             handleCount += queryMessageList.size
-            ctx.defaultSharedPreferences.putInt(PREF_SYNC_FTS4_OFFSET, offset)
+            PropertyHelper.updateKeyValue(ctx, PREF_SYNC_FTS4_OFFSET, offset.toString())
             onProgressChanged?.invoke((offset.toFloat() / PRE_PROCESS_COUNT * 100).toInt())
             Timber.d("syncMessageFts4 handle 100 messages cost ${System.currentTimeMillis() - start}, offset: $offset")
 

--- a/app/src/main/java/one/mixin/android/util/PropertyHelper.kt
+++ b/app/src/main/java/one/mixin/android/util/PropertyHelper.kt
@@ -1,0 +1,108 @@
+package one.mixin.android.util
+
+import android.content.Context
+import one.mixin.android.Constants.Account.PREF_ATTACHMENT
+import one.mixin.android.Constants.Account.PREF_ATTACHMENT_LAST
+import one.mixin.android.Constants.Account.PREF_ATTACHMENT_OFFSET
+import one.mixin.android.Constants.Account.PREF_BACKUP
+import one.mixin.android.Constants.Account.PREF_DUPLICATE_TRANSFER
+import one.mixin.android.Constants.Account.PREF_FTS4_UPGRADE
+import one.mixin.android.Constants.Account.PREF_STRANGER_TRANSFER
+import one.mixin.android.Constants.Account.PREF_SYNC_FTS4_OFFSET
+import one.mixin.android.Constants.BackUp.BACKUP_LAST_TIME
+import one.mixin.android.Constants.BackUp.BACKUP_PERIOD
+import one.mixin.android.Constants.Download.AUTO_DOWNLOAD_MOBILE
+import one.mixin.android.Constants.Download.AUTO_DOWNLOAD_ROAMING
+import one.mixin.android.Constants.Download.AUTO_DOWNLOAD_WIFI
+import one.mixin.android.Constants.Download.MOBILE_DEFAULT
+import one.mixin.android.Constants.Download.ROAMING_DEFAULT
+import one.mixin.android.Constants.Download.WIFI_DEFAULT
+import one.mixin.android.db.MixinDatabase
+import one.mixin.android.db.PropertyDao
+import one.mixin.android.extension.defaultSharedPreferences
+import one.mixin.android.extension.nowInUtc
+import one.mixin.android.vo.Property
+
+object PropertyHelper {
+
+    private const val PREF_PROPERTY_MIGRATED = "pref_property_migrated"
+
+    suspend fun checkFts4Upgrade(context: Context, action: () -> Unit) {
+        checkWithKey(context, PREF_FTS4_UPGRADE, true.toString(), action)
+    }
+
+    suspend fun checkAttachmentMigrated(context: Context, action: () -> Unit) {
+        checkWithKey(context, PREF_ATTACHMENT, true.toString(), action)
+    }
+
+    suspend fun checkBackupMigrated(context: Context, action: () -> Unit) {
+        checkWithKey(context, PREF_BACKUP, true.toString(), action)
+    }
+
+    suspend fun checkMigrated(context: Context): PropertyDao {
+        val propertyDao = MixinDatabase.getDatabase(context).propertyDao()
+        if (!hasMigrated(propertyDao)) {
+            migrateProperties(context, propertyDao)
+        }
+        return propertyDao
+    }
+
+    suspend fun updateKeyValue(context: Context, key: String, value: String) {
+        val propertyDao = MixinDatabase.getDatabase(context).propertyDao()
+        propertyDao.insertSuspend(Property(key, value, nowInUtc()))
+    }
+
+    suspend fun findValueByKey(context: Context, key: String): String? {
+        val propertyDao = MixinDatabase.getDatabase(context).propertyDao()
+        return propertyDao.findValueByKey(key)
+    }
+
+    private suspend fun checkWithKey(context: Context, key: String, expectValue: String, action: () -> Unit) {
+        val propertyDao = checkMigrated(context)
+
+        val value = propertyDao.findValueByKey(key)
+        if (value != expectValue) {
+            action.invoke()
+        }
+    }
+
+    private suspend fun migrateProperties(context: Context, propertyDao: PropertyDao) {
+        val pref = context.defaultSharedPreferences
+        val updatedAt = nowInUtc()
+        val fts4Upgrade = pref.getBoolean(PREF_FTS4_UPGRADE, false)
+        propertyDao.insertSuspend(Property(PREF_FTS4_UPGRADE, fts4Upgrade.toString(), updatedAt))
+        val syncFtsOffset = pref.getInt(PREF_SYNC_FTS4_OFFSET, 0)
+        propertyDao.insertSuspend(Property(PREF_SYNC_FTS4_OFFSET, syncFtsOffset.toString(), updatedAt))
+
+        val attachment = pref.getBoolean(PREF_ATTACHMENT, false)
+        propertyDao.insertSuspend(Property(PREF_ATTACHMENT, attachment.toString(), updatedAt))
+        val attachmentLast = pref.getLong(PREF_ATTACHMENT_LAST, -1)
+        propertyDao.insertSuspend(Property(PREF_ATTACHMENT_LAST, attachmentLast.toString(), updatedAt))
+        val attachmentOffset = pref.getLong(PREF_ATTACHMENT_OFFSET, 0)
+        propertyDao.insertSuspend(Property(PREF_ATTACHMENT_OFFSET, attachmentOffset.toString(), updatedAt))
+
+        val backup = pref.getBoolean(PREF_BACKUP, false)
+        propertyDao.insertSuspend(Property(PREF_BACKUP, backup.toString(), updatedAt))
+        val period = pref.getInt(BACKUP_PERIOD, 0)
+        propertyDao.insertSuspend(Property(BACKUP_PERIOD, period.toString(), updatedAt))
+        val lastTime = pref.getLong(BACKUP_LAST_TIME, System.currentTimeMillis())
+        propertyDao.insertSuspend(Property(BACKUP_LAST_TIME, lastTime.toString(), updatedAt))
+
+        val duplicateTransfer = pref.getBoolean(PREF_DUPLICATE_TRANSFER, true)
+        propertyDao.insertSuspend(Property(PREF_DUPLICATE_TRANSFER, duplicateTransfer.toString(), updatedAt))
+        val strangerTransfer = pref.getBoolean(PREF_STRANGER_TRANSFER, true)
+        propertyDao.insertSuspend(Property(PREF_STRANGER_TRANSFER, strangerTransfer.toString(), updatedAt))
+
+        val autoWifi = pref.getInt(AUTO_DOWNLOAD_WIFI, WIFI_DEFAULT)
+        propertyDao.insertSuspend(Property(AUTO_DOWNLOAD_WIFI, autoWifi.toString(), updatedAt))
+        val autoMobile = pref.getInt(AUTO_DOWNLOAD_MOBILE, MOBILE_DEFAULT)
+        propertyDao.insertSuspend(Property(AUTO_DOWNLOAD_MOBILE, autoMobile.toString(), updatedAt))
+        val autoRoaming = pref.getInt(AUTO_DOWNLOAD_ROAMING, ROAMING_DEFAULT)
+        propertyDao.insertSuspend(Property(AUTO_DOWNLOAD_ROAMING, autoRoaming.toString(), updatedAt))
+
+        propertyDao.insertSuspend(Property(PREF_PROPERTY_MIGRATED, true.toString(), updatedAt))
+    }
+
+    private suspend fun hasMigrated(propertyDao: PropertyDao) =
+        propertyDao.findValueByKey(PREF_PROPERTY_MIGRATED)?.toBoolean() == true
+}

--- a/app/src/main/java/one/mixin/android/vo/Conversation.kt
+++ b/app/src/main/java/one/mixin/android/vo/Conversation.kt
@@ -10,7 +10,7 @@ import java.util.UUID
 @Entity(
     tableName = "conversations",
     indices = [
-        Index(value = arrayOf("pin_time", "last_message_created_at"))
+        Index(value = arrayOf("pin_time", "last_message_created_at")),
     ],
 )
 open class Conversation(

--- a/app/src/main/java/one/mixin/android/vo/Property.kt
+++ b/app/src/main/java/one/mixin/android/vo/Property.kt
@@ -1,0 +1,16 @@
+package one.mixin.android.vo
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "properties")
+data class Property(
+    @PrimaryKey
+    @ColumnInfo(name = "key")
+    val key: String,
+    @ColumnInfo(name = "value")
+    val value: String,
+    @ColumnInfo(name = "updated_at")
+    val updatedAt: String,
+)


### PR DESCRIPTION
This PR relates to https://github.com/MixinNetwork/android-app/issues/1965 and contains following changes.

- a new table named "properties" has been added to store some of the key-values previously stored in SharedPreferences
> CREATE TABLE IF NOT EXISTS `properties` (`key` TEXT NOT NULL, `value` TEXT NOT NULL, `updated_at` TEXT NOT NULL, PRIMARY KEY(`key`))

- migrate the target key-values from SP to table "properties" when upgrading DB
- check for these migrated key-values ​​usages