### PR TITLE
Revert "Bump appCenterSdkVersion from 4.3.1 to 4.4.1 (#2683)"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -97,7 +97,7 @@ buildscript {
         ext.svgVersion = '1.4'
         ext.startupVersion ='1.1.0'
         ext.dnsVersion = '2.1.9'
-        ext.appCenterSdkVersion = '4.4.1'
+        ext.appCenterSdkVersion = '4.3.1'
         ext.audioSwitchVersion = '1.1.3'
         ext.balloonVersion = '1.4.0'
 


### PR DESCRIPTION
This reverts commit 29249ba5b1e8e92f650edd6b688b018d7ed42d86.

https://github.com/microsoft/appcenter-sdk-android/issues/1584

https://github.com/microsoft/appcenter-sdk-android/pull/1585