### PR TITLE
feat: implement and optimize user property reporting for analytics

### DIFF
--- a/app/src/main/java/one/mixin/android/job/DecryptMessage.kt
+++ b/app/src/main/java/one/mixin/android/job/DecryptMessage.kt
@@ -56,6 +56,7 @@ import one.mixin.android.ui.web.replaceApp
 import one.mixin.android.util.ColorUtil
 import one.mixin.android.util.GsonHelper
 import one.mixin.android.util.PENDING_DB_THREAD
+import one.mixin.android.util.analytics.AnalyticsTracker
 import one.mixin.android.util.hyperlink.parseHyperlink
 import one.mixin.android.util.mention.parseMentionData
 import one.mixin.android.util.reportException
@@ -1158,6 +1159,7 @@ class DecryptMessage(private val lifecycleScope: CoroutineScope) : Injector() {
         snapshotDao.insert(snapshot)
         insertMessage(message, data)
         jobManager.addJobInBackground(RefreshAssetsJob(snapshot.assetId))
+        runBlocking { AnalyticsTracker.setAssetLevel(tokenDao.findTotalUSDBalance() ?: 0) }
 
         if (snapshot.type == SnapshotType.transfer.name && snapshot.amount.toFloat() > 0) {
             generateNotification(message, data)
@@ -1191,6 +1193,7 @@ class DecryptMessage(private val lifecycleScope: CoroutineScope) : Injector() {
         insertMessage(message, data)
         jobManager.addJobInBackground(RefreshTokensJob(snapshot.assetId, data.conversationId, data.messageId))
         jobManager.addJobInBackground(SyncOutputJob())
+        runBlocking { AnalyticsTracker.setAssetLevel(tokenDao.findTotalUSDBalance() ?: 0) }
 
         if (snapshot.amount.toFloat() > 0) {
             generateNotification(message, data)

--- a/app/src/main/java/one/mixin/android/job/DecryptMessage.kt
+++ b/app/src/main/java/one/mixin/android/job/DecryptMessage.kt
@@ -68,6 +68,7 @@ import one.mixin.android.vo.CircleConversation
 import one.mixin.android.vo.ConversationStatus
 import one.mixin.android.vo.ExpiredMessage
 import one.mixin.android.vo.Account
+import one.mixin.android.vo.MediaStatus
 import one.mixin.android.vo.Message
 import one.mixin.android.vo.MessageCategory
 import one.mixin.android.vo.MessageHistory

--- a/app/src/main/java/one/mixin/android/job/DecryptMessage.kt
+++ b/app/src/main/java/one/mixin/android/job/DecryptMessage.kt
@@ -66,7 +66,7 @@ import one.mixin.android.vo.AttachmentExtra
 import one.mixin.android.vo.CircleConversation
 import one.mixin.android.vo.ConversationStatus
 import one.mixin.android.vo.ExpiredMessage
-import one.mixin.android.vo.MediaStatus
+import one.mixin.android.vo.Account
 import one.mixin.android.vo.Message
 import one.mixin.android.vo.MessageCategory
 import one.mixin.android.vo.MessageHistory

--- a/app/src/main/java/one/mixin/android/job/RefreshAccountJob.kt
+++ b/app/src/main/java/one/mixin/android/job/RefreshAccountJob.kt
@@ -38,7 +38,7 @@ class RefreshAccountJob(
                     RxBus.publish(MembershipEvent())
                 }
                 if (checkTip) { // from home page
-                    AnalyticsTracker.setHasEmergencyContact(account)
+                    AnalyticsTracker.setHasRecoveryContact(account)
                     AnalyticsTracker.setMembership(account)
                 }
 

--- a/app/src/main/java/one/mixin/android/job/RefreshAssetsJob.kt
+++ b/app/src/main/java/one/mixin/android/job/RefreshAssetsJob.kt
@@ -2,6 +2,7 @@ package one.mixin.android.job
 
 import com.birbit.android.jobqueue.Params
 import kotlinx.coroutines.runBlocking
+import one.mixin.android.util.analytics.AnalyticsTracker
 import one.mixin.android.vo.Asset
 import one.mixin.android.vo.Fiats
 
@@ -42,6 +43,7 @@ class RefreshAssetsJob(
                 }
                 refreshFiats()
             }
+            AnalyticsTracker.setAssetLevel(tokenDao.findTotalUSDBalance() ?: 0)
         }
 
     private suspend fun refreshFiats() {

--- a/app/src/main/java/one/mixin/android/job/RefreshTokensJob.kt
+++ b/app/src/main/java/one/mixin/android/job/RefreshTokensJob.kt
@@ -3,6 +3,7 @@ package one.mixin.android.job
 import com.birbit.android.jobqueue.Params
 import kotlinx.coroutines.runBlocking
 import one.mixin.android.db.flow.MessageFlow
+import one.mixin.android.util.analytics.AnalyticsTracker
 import one.mixin.android.vo.Fiats
 import one.mixin.android.vo.safe.Token
 import timber.log.Timber
@@ -46,6 +47,7 @@ class RefreshTokensJob(
                 }
                 refreshFiats()
             }
+            AnalyticsTracker.setAssetLevel(tokenDao.findTotalUSDBalance() ?: 0)
         }
 
     private suspend fun refreshAsset() {

--- a/app/src/main/java/one/mixin/android/ui/address/TransferDestinationInputFragment.kt
+++ b/app/src/main/java/one/mixin/android/ui/address/TransferDestinationInputFragment.kt
@@ -62,6 +62,7 @@ import one.mixin.android.ui.wallet.TransferContactBottomSheetDialogFragment
 import one.mixin.android.ui.wallet.WalletListBottomSheetDialogFragment
 import one.mixin.android.ui.wallet.transfer.TransferBottomSheetDialogFragment
 import one.mixin.android.util.ErrorHandler
+import one.mixin.android.util.analytics.AnalyticsTracker
 import one.mixin.android.util.decodeICAP
 import one.mixin.android.util.getMixinErrorStringByCode
 import one.mixin.android.util.isIcapAddress
@@ -246,6 +247,7 @@ class TransferDestinationInputFragment() : BaseFragment(R.layout.fragment_addres
                                         TransferContactBottomSheetDialogFragment.newInstance()
                                             .apply {
                                                 onUserClick = { user ->
+                                                    AnalyticsTracker.trackAssetSendRecipient(AnalyticsTracker.AssetSendRecipientType.CONTACT)
                                                     navigateToInputFragmentWithBundle(
                                                         Bundle().apply {
                                                             putParcelable(InputFragment.ARGS_TO_USER, user)
@@ -268,6 +270,7 @@ class TransferDestinationInputFragment() : BaseFragment(R.layout.fragment_addres
                                                             toast(R.string.Alert_Not_Support)
                                                             return@launch
                                                         }
+                                                        AnalyticsTracker.trackAssetSendRecipient(AnalyticsTracker.AssetSendRecipientType.CONTACT)
                                                         val chain = chainToken ?: web3ViewModel.web3TokenItemById(t.walletId, t.chainId)
                                                         if (chain == null) {
                                                             toast(R.string.Alert_Not_Support)
@@ -298,6 +301,7 @@ class TransferDestinationInputFragment() : BaseFragment(R.layout.fragment_addres
                                             this@TransferDestinationInputFragment.lifecycleScope.launch(CoroutineExceptionHandler { _, error ->
                                                 Timber.e(error)
                                             }) {
+                                                AnalyticsTracker.trackAssetSendRecipient(AnalyticsTracker.AssetSendRecipientType.WALLET)
                                                 when {
                                                     destinationWallet?.isMixinSafe()  == true-> {
                                                         val toAddress = destinationWallet.safeAddress.orEmpty()
@@ -383,6 +387,7 @@ class TransferDestinationInputFragment() : BaseFragment(R.layout.fragment_addres
 
                                 },
                                 toAddAddress = {
+                                    AnalyticsTracker.trackAddressBookAddStart()
                                     navController.navigate(TransferDestination.Address.name)
                                 },
                                 onSend = { address ->
@@ -393,6 +398,7 @@ class TransferDestinationInputFragment() : BaseFragment(R.layout.fragment_addres
                                             LinkBottomSheetDialogFragment.TAG
                                         )
                                     } else {
+                                        AnalyticsTracker.trackAssetSendRecipient(AnalyticsTracker.AssetSendRecipientType.ADDRESS)
                                         val memoEnabled =
                                             token?.withdrawalMemoPossibility == WithdrawalMemoPossibility.POSITIVE || token?.withdrawalMemoPossibility == WithdrawalMemoPossibility.POSSIBLE
                                         if (memoEnabled) {
@@ -441,6 +447,7 @@ class TransferDestinationInputFragment() : BaseFragment(R.layout.fragment_addres
                                 errorInfo = errorInfo,
                                 onAddressClick = { address ->
                                     requireView().hideKeyboard()
+                                    AnalyticsTracker.trackAssetSendRecipient(AnalyticsTracker.AssetSendRecipientType.ADDRESS_BOOK)
                                     if (web3Token != null) {
                                         val dialog =
                                             indeterminateProgressDialog(message = R.string.Please_wait_a_bit).apply {
@@ -493,6 +500,7 @@ class TransferDestinationInputFragment() : BaseFragment(R.layout.fragment_addres
                                     AddressSearchBottomSheetDialogFragment.newInstance(chainId).apply {
                                         onAddressClick = { address ->
                                             this@TransferDestinationInputFragment.requireView().hideKeyboard()
+                                            AnalyticsTracker.trackAssetSendRecipient(AnalyticsTracker.AssetSendRecipientType.ADDRESS_BOOK)
                                             if (web3Token != null) {
                                                 val selectedWeb3Token = web3Token!!
                                                 val dialog =
@@ -548,6 +556,7 @@ class TransferDestinationInputFragment() : BaseFragment(R.layout.fragment_addres
                                             }
                                         }
                                         onAddClick = {
+                                            AnalyticsTracker.trackAddressBookAddStart()
                                             navController.navigate(TransferDestination.Address.name)
                                         }
                                     }.show(parentFragmentManager, AddressSearchBottomSheetDialogFragment.TAG)
@@ -602,6 +611,7 @@ class TransferDestinationInputFragment() : BaseFragment(R.layout.fragment_addres
                                 onNext = { memo ->
                                     errorInfo = null
                                     requireView().hideKeyboard()
+                                    AnalyticsTracker.trackAddressBookAddMemo("memo")
                                     validateAndNavigateToInput(
                                         assetId = token?.assetId ?: web3Token?.assetId ?: "",
                                         chainId = token?.chainId ?: web3Token?.chainId ?: "",
@@ -631,6 +641,7 @@ class TransferDestinationInputFragment() : BaseFragment(R.layout.fragment_addres
                                 contentText = scannedMemo,
                                 onNext = { memo ->
                                     errorInfo = null
+                                    AnalyticsTracker.trackAddressBookAddMemo("memo")
                                     validateAndNavigateToInput(
                                         assetId = token?.assetId ?: web3Token?.assetId ?: "",
                                         chainId = token?.chainId ?: web3Token?.chainId ?: "",
@@ -671,6 +682,7 @@ class TransferDestinationInputFragment() : BaseFragment(R.layout.fragment_addres
                                 onScan = { startQrScan(ScanType.LABEL) },
                                 onComplete = { label ->
                                     errorInfo = null
+                                    AnalyticsTracker.trackAddressBookAddLabel()
                                     if (token == null && web3Token != null) {
                                         this@TransferDestinationInputFragment.lifecycleScope.launch {
                                             val t = web3ViewModel.syncAsset(web3Token!!.assetId) ?: return@launch
@@ -836,6 +848,7 @@ class TransferDestinationInputFragment() : BaseFragment(R.layout.fragment_addres
                 type = TransferBottomSheetDialogFragment.ADD,
             ),
         )
+        AnalyticsTracker.trackAddressBookAddPreview()
         bottomSheet.showNow(
             parentFragmentManager,
             TransferBottomSheetDialogFragment.TAG

--- a/app/src/main/java/one/mixin/android/ui/conversation/ConversationFragment.kt
+++ b/app/src/main/java/one/mixin/android/ui/conversation/ConversationFragment.kt
@@ -2691,6 +2691,7 @@ class ConversationFragment() :
                             menu.app?.let { app ->
                                 binding.chatControl.chatEt.hideKeyboard()
                                 AnalyticsTracker.trackOpenBotHomePage(AnalyticsTracker.BotSource.CHAT_BOTTOM_MENU, app.appNumber)
+                                AnalyticsTracker.trackOpenBotConversation(AnalyticsTracker.BotSource.CHAT_MORE_MENU, app.appNumber)
                                 WebActivity.show(
                                     requireActivity(),
                                     app.homeUri,

--- a/app/src/main/java/one/mixin/android/ui/home/ConversationListFragment.kt
+++ b/app/src/main/java/one/mixin/android/ui/home/ConversationListFragment.kt
@@ -365,10 +365,14 @@ class ConversationListFragment : LinkFragment() {
     }
 
     private fun analytics() {
-        lifecycleScope.launch{
+        lifecycleScope.launch {
             val totalUsd = conversationListViewModel.findTotalUSDBalance()
             AnalyticsTracker.setAssetLevel(totalUsd)
             AnalyticsTracker.setNotificationAuthStatus(requireContext())
+            Session.getAccount()?.let {
+                AnalyticsTracker.setHasRecoveryContact(it)
+                AnalyticsTracker.setMembership(it)
+            }
         }
     }
 

--- a/app/src/main/java/one/mixin/android/ui/home/MainActivity.kt
+++ b/app/src/main/java/one/mixin/android/ui/home/MainActivity.kt
@@ -132,7 +132,6 @@ import one.mixin.android.tip.wc.WalletConnectV2
 import one.mixin.android.ui.common.BaseFragment
 import one.mixin.android.ui.common.BatteryOptimizationDialogActivity
 import one.mixin.android.ui.common.BlazeBaseActivity
-import one.mixin.android.util.analytics.AnalyticsTracker
 import one.mixin.android.ui.common.LoginVerifyBottomSheetDialogFragment
 import one.mixin.android.ui.common.NavigationController
 import one.mixin.android.ui.common.PinCodeFragment.Companion.FROM_EMERGENCY
@@ -1125,11 +1124,13 @@ class MainActivity : BlazeBaseActivity(), WalletMissingBtcAddressFragment.Callba
     private fun handleNavigationItemSelected(itemId: Int) {
         when (itemId) {
             R.id.nav_chat -> {
+                AnalyticsTracker.trackHomeTabSwitch(AnalyticsTracker.HomeTabMethod.CHATS)
                 switchToDestination(NavigationController.ConversationList)
                 lastBottomNavItemId = itemId
             }
 
             R.id.nav_wallet -> {
+                AnalyticsTracker.trackHomeTabSwitch(AnalyticsTracker.HomeTabMethod.WALLETS)
                 Timber.e("nav_wallet: ${Session.getAccount()?.hasPin}")
                 if (Session.getAccount()?.hasPin == true) {
                     lifecycleScope.launch {
@@ -1151,6 +1152,7 @@ class MainActivity : BlazeBaseActivity(), WalletMissingBtcAddressFragment.Callba
             }
 
             R.id.nav_market -> {
+                AnalyticsTracker.trackMoreTabSwitch(AnalyticsTracker.MoreTabMethod.MARKETS)
                 switchToDestination(NavigationController.Market)
                 lastBottomNavItemId = itemId
                 findFragmentByTagTyped<MarketFragment>(NavigationController.Market.tag)?.updateUI()
@@ -1159,6 +1161,8 @@ class MainActivity : BlazeBaseActivity(), WalletMissingBtcAddressFragment.Callba
             }
 
             R.id.nav_more -> {
+                AnalyticsTracker.trackHomeTabSwitch(AnalyticsTracker.HomeTabMethod.MORE)
+                AnalyticsTracker.trackMoreTabSwitch(AnalyticsTracker.MoreTabMethod.BOTS)
                 if (!defaultSharedPreferences.getBoolean(Account.PREF_NAV_MORE_BADGE_DISMISSED, false)) {
                     defaultSharedPreferences.putBoolean(Account.PREF_NAV_MORE_BADGE_DISMISSED, true)
                     RxBus.publish(BadgeEvent(Account.PREF_NAV_MORE_BADGE_DISMISSED))

--- a/app/src/main/java/one/mixin/android/ui/home/MainActivity.kt
+++ b/app/src/main/java/one/mixin/android/ui/home/MainActivity.kt
@@ -132,6 +132,7 @@ import one.mixin.android.tip.wc.WalletConnectV2
 import one.mixin.android.ui.common.BaseFragment
 import one.mixin.android.ui.common.BatteryOptimizationDialogActivity
 import one.mixin.android.ui.common.BlazeBaseActivity
+import one.mixin.android.util.analytics.AnalyticsTracker
 import one.mixin.android.ui.common.LoginVerifyBottomSheetDialogFragment
 import one.mixin.android.ui.common.NavigationController
 import one.mixin.android.ui.common.PinCodeFragment.Companion.FROM_EMERGENCY
@@ -442,7 +443,9 @@ class MainActivity : BlazeBaseActivity(), WalletMissingBtcAddressFragment.Callba
                 .request(Manifest.permission.POST_NOTIFICATIONS)
                 .autoDispose(stopScope)
                 .subscribe(
-                    { _ -> },
+                    { _ -> 
+                        AnalyticsTracker.setNotificationAuthStatus(this)
+                    },
                     {},
                 )
         }

--- a/app/src/main/java/one/mixin/android/ui/home/web3/trade/TradeFragment.kt
+++ b/app/src/main/java/one/mixin/android/ui/home/web3/trade/TradeFragment.kt
@@ -367,6 +367,12 @@ class TradeFragment : BaseFragment() {
                                 },
                                 onReview = { quote, from, to, amount ->
                                     AnalyticsTracker.trackTradePreview()
+                                    AnalyticsTracker.trackSpotPreview(
+                                        sendChain = from.chain.name,
+                                        sendAssetSymbol = from.symbol,
+                                        receiveChain = to.chain.name,
+                                        receiveAssetSymbol = to.symbol,
+                                    )
                                     this@apply.hideKeyboard()
                                     reviewing = true
                                     lifecycleScope.launch {
@@ -380,6 +386,12 @@ class TradeFragment : BaseFragment() {
                                 },
                                 onLimitReview = { from, to, order ->
                                     AnalyticsTracker.trackTradePreview()
+                                    AnalyticsTracker.trackSpotPreview(
+                                        sendChain = from.chain.name,
+                                        sendAssetSymbol = from.symbol,
+                                        receiveChain = to.chain.name,
+                                        receiveAssetSymbol = to.symbol,
+                                    )
                                     this@apply.hideKeyboard()
                                     reviewing = true
                                     lifecycleScope.launch {
@@ -815,13 +827,6 @@ class TradeFragment : BaseFragment() {
         to: SwapToken,
         previewData: SwapTransferPreviewData?,
     ) {
-        AnalyticsTracker.trackTradePreview()
-        AnalyticsTracker.trackSpotPreview(
-            sendChain = from.chain.name,
-            sendAssetSymbol = from.symbol,
-            receiveChain = to.chain.name,
-            receiveAssetSymbol = to.symbol,
-        )
         SwapTransferBottomSheetDialogFragment.newInstance(swapResult, from, to, previewData).apply {
             setOnDone {
                 initialAmount = null
@@ -834,13 +839,6 @@ class TradeFragment : BaseFragment() {
     }
 
     private suspend fun openLimitTransfer(from: SwapToken, to: SwapToken, order: CreateLimitOrderResponse) {
-        AnalyticsTracker.trackTradePreview()
-        AnalyticsTracker.trackSpotPreview(
-            sendChain = from.chain.name,
-            sendAssetSymbol = from.symbol,
-            receiveChain = to.chain.name,
-            receiveAssetSymbol = to.symbol,
-        )
         val senderWalletId = if (inMixin()) Session.getAccountId()!! else Web3Signer.currentWalletId
         if (!inMixin()) {
             val address = swapViewModel.getAddressesByChainId(Web3Signer.currentWalletId, to.chain.chainId)

--- a/app/src/main/java/one/mixin/android/ui/home/web3/trade/TradeFragment.kt
+++ b/app/src/main/java/one/mixin/android/ui/home/web3/trade/TradeFragment.kt
@@ -542,7 +542,13 @@ class TradeFragment : BaseFragment() {
                                     )
                                 },
                                 onClosedPositionClick = { position ->
-                                    navTo(PositionDetailFragment.newInstance(position), PositionDetailFragment.TAG)
+                                    navTo(
+                                        PositionDetailFragment.newInstance(
+                                            position,
+                                            AnalyticsTracker.PerpsSource.PERPS_HOME_LIST,
+                                        ),
+                                        PositionDetailFragment.TAG,
+                                    )
                                 }
                             )
                         }

--- a/app/src/main/java/one/mixin/android/ui/home/web3/trade/perps/AllPositionsFragment.kt
+++ b/app/src/main/java/one/mixin/android/ui/home/web3/trade/perps/AllPositionsFragment.kt
@@ -63,7 +63,9 @@ class AllPositionsFragment : BaseFragment() {
             else -> AllPositionsType.CLOSED
         }
         val source = arguments?.getString(ARGS_SOURCE) ?: AnalyticsTracker.PerpsSource.PERPS_ALL_POSITIONS
-        AnalyticsTracker.trackPerpsAllPositions(source)
+        if (positionType == AllPositionsType.OPEN) {
+            AnalyticsTracker.trackPerpsAllPositions(source)
+        }
         if (positionType == AllPositionsType.CLOSED) {
             AnalyticsTracker.trackPerpsActivity(source)
         }

--- a/app/src/main/java/one/mixin/android/ui/home/web3/trade/perps/AllPositionsFragment.kt
+++ b/app/src/main/java/one/mixin/android/ui/home/web3/trade/perps/AllPositionsFragment.kt
@@ -122,7 +122,7 @@ class AllPositionsFragment : BaseFragment() {
                                     )
                                     .add(
                                         android.R.id.content,
-                                        PositionDetailFragment.newInstance(position, AnalyticsTracker.PerpsSource.PERPS_ALL_POSITIONS),
+                                        PositionDetailFragment.newInstance(position, AnalyticsTracker.PerpsSource.PERPS_ACTIVITY_LIST),
                                         PositionDetailFragment.TAG,
                                     )
                                     .addToBackStack(null)

--- a/app/src/main/java/one/mixin/android/ui/home/web3/trade/perps/PositionDetailFragment.kt
+++ b/app/src/main/java/one/mixin/android/ui/home/web3/trade/perps/PositionDetailFragment.kt
@@ -35,16 +35,15 @@ class PositionDetailFragment : BaseFragment() {
         private const val ARGS_SOURCE = "args_source"
         private const val POSITION_REFRESH_INTERVAL_MS = 10_000L
 
-        fun newInstance(position: PerpsPositionItem, source: String = AnalyticsTracker.PerpsSource.PERPS_ACTIVITY_DETAIL): PositionDetailFragment {
+        fun newInstance(position: PerpsPositionItem): PositionDetailFragment {
             return PositionDetailFragment().apply {
                 arguments = Bundle().apply {
                     putParcelable(ARGS_POSITION, position)
-                    putString(ARGS_SOURCE, source)
                 }
             }
         }
 
-        fun newInstance(position: PerpsPositionHistoryItem, source: String = AnalyticsTracker.PerpsSource.PERPS_ACTIVITY_DETAIL): PositionDetailFragment {
+        fun newInstance(position: PerpsPositionHistoryItem, source: String): PositionDetailFragment {
             return PositionDetailFragment().apply {
                 arguments = Bundle().apply {
                     putParcelable(ARGS_POSITION_HISTORY, position)
@@ -67,8 +66,10 @@ class PositionDetailFragment : BaseFragment() {
     ): View {
         val position = arguments?.getParcelableCompat(ARGS_POSITION, PerpsPositionItem::class.java)
         val positionHistory = arguments?.getParcelableCompat(ARGS_POSITION_HISTORY, PerpsPositionHistoryItem::class.java)
-        val source = arguments?.getString(ARGS_SOURCE) ?: AnalyticsTracker.PerpsSource.PERPS_ACTIVITY_DETAIL
-        AnalyticsTracker.trackPerpsActivityDetail(source)
+        if (positionHistory != null) {
+            val source = arguments?.getString(ARGS_SOURCE) ?: AnalyticsTracker.PerpsSource.PERPS_ACTIVITY_LIST
+            AnalyticsTracker.trackPerpsActivityDetail(source)
+        }
 
         return ComposeView(inflater.context).apply {
             setContent {

--- a/app/src/main/java/one/mixin/android/ui/setting/EmergencyContactFragment.kt
+++ b/app/src/main/java/one/mixin/android/ui/setting/EmergencyContactFragment.kt
@@ -17,6 +17,7 @@ import one.mixin.android.extension.openUrl
 import one.mixin.android.session.Session
 import one.mixin.android.ui.common.BaseFragment
 import one.mixin.android.ui.common.VerifyFragment
+import one.mixin.android.util.analytics.AnalyticsTracker
 import one.mixin.android.util.viewBinding
 import one.mixin.android.vo.Account
 import one.mixin.android.vo.User
@@ -133,6 +134,7 @@ class EmergencyContactFragment : BaseFragment(R.layout.fragment_emergency_contac
                         val a = response.data as Account
                         Session.storeAccount(a)
                         Session.setHasEmergencyContact(a.hasEmergencyContact)
+                        AnalyticsTracker.setHasRecoveryContact(a)
                         setEmergencySet()
                     },
                     exceptionBlock = {

--- a/app/src/main/java/one/mixin/android/ui/setting/VerificationEmergencyFragment.kt
+++ b/app/src/main/java/one/mixin/android/ui/setting/VerificationEmergencyFragment.kt
@@ -31,6 +31,7 @@ import one.mixin.android.ui.common.PinCodeFragment
 import one.mixin.android.ui.landing.LandingActivity.Companion.ARGS_PIN
 import one.mixin.android.ui.logs.LogViewerBottomSheet
 import one.mixin.android.util.viewBinding
+import one.mixin.android.util.analytics.AnalyticsTracker
 import one.mixin.android.vo.Account
 import one.mixin.android.vo.User
 import timber.log.Timber
@@ -127,6 +128,7 @@ class VerificationEmergencyFragment : PinCodeFragment(R.layout.fragment_verifica
                     Session.storeAccount(a)
                     resolveCurrentUserScopeManager(requireContext()).enter(a)
                     Session.setHasEmergencyContact(a.hasEmergencyContact)
+                    AnalyticsTracker.setHasRecoveryContact(a)
                     activity?.supportFragmentManager?.findFragmentByTag(EmergencyContactFragment.TAG)?.let {
                         (it as? EmergencyContactFragment)?.setEmergencySet()
                     }

--- a/app/src/main/java/one/mixin/android/ui/setting/ui/page/EmergencyContactPage.kt
+++ b/app/src/main/java/one/mixin/android/ui/setting/ui/page/EmergencyContactPage.kt
@@ -40,6 +40,7 @@ import one.mixin.android.extension.findFragmentActivityOrNull
 import one.mixin.android.extension.inTransaction
 import one.mixin.android.extension.openUrl
 import one.mixin.android.session.Session
+import one.mixin.android.util.analytics.AnalyticsTracker
 import one.mixin.android.ui.common.VerifyFragment
 import one.mixin.android.ui.common.biometric.BiometricBottomSheetDialogFragment
 import one.mixin.android.ui.setting.EmergencyViewModel
@@ -220,6 +221,7 @@ private fun RemoveEmergencyButton(
                             val a = response.data as Account
                             Session.storeAccount(a)
                             Session.setHasEmergencyContact(a.hasEmergencyContact)
+                            AnalyticsTracker.setHasRecoveryContact(a)
                             Timber.d("delete emergency contact success: ${a.hasEmergencyContact}")
                             onEmergencyAccountRemoved()
                         },

--- a/app/src/main/java/one/mixin/android/ui/tip/TipFragment.kt
+++ b/app/src/main/java/one/mixin/android/ui/tip/TipFragment.kt
@@ -350,7 +350,10 @@ class TipFragment : BaseFragment(R.layout.fragment_tip) {
     private fun processTip() =
         lifecycleScope.launch {
             when (tipBundle.tipType) {
-                TipType.Change -> AnalyticsTracker.trackLoginPinVerify("pin_change")
+                TipType.Change -> {
+                    AnalyticsTracker.trackLoginPinVerify("pin_change")
+                    AnalyticsTracker.trackAccountResumePin(AnalyticsTracker.AccountResumePinType.PIN_CHANGE)
+                }
                 TipType.Upgrade -> AnalyticsTracker.trackLoginPinVerify("pin_upgrade")
                 else -> Unit
             }

--- a/app/src/main/java/one/mixin/android/ui/wallet/AllTransactionsFragment.kt
+++ b/app/src/main/java/one/mixin/android/ui/wallet/AllTransactionsFragment.kt
@@ -40,6 +40,7 @@ import one.mixin.android.ui.wallet.TransactionFragment.Companion.ARGS_SNAPSHOT
 import one.mixin.android.ui.wallet.TransactionsFragment.Companion.ARGS_ASSET
 import one.mixin.android.ui.wallet.adapter.OnSnapshotListener
 import one.mixin.android.ui.wallet.adapter.SnapshotPagedAdapter
+import one.mixin.android.util.analytics.AnalyticsTracker
 import one.mixin.android.util.reportException
 import one.mixin.android.util.viewBinding
 import one.mixin.android.vo.AddressItem
@@ -98,6 +99,7 @@ class AllTransactionsFragment : BaseTransactionsFragment(R.layout.fragment_all_t
         savedInstanceState: Bundle?,
     ) {
         super.onViewCreated(view, savedInstanceState)
+        AnalyticsTracker.trackAllTransactions(AnalyticsTracker.AssetSource.WALLET_HOME)
 
         adapter.listener = this
         binding.apply {
@@ -193,6 +195,7 @@ class AllTransactionsFragment : BaseTransactionsFragment(R.layout.fragment_all_t
     }
 
     override fun <T> onNormalItemClick(item: T) {
+        AnalyticsTracker.trackTransactionDetail(AnalyticsTracker.AssetSource.ALL_TRANSACTIONS)
         lifecycleScope.launch {
             val snapshot = item as SnapshotItem
             val a =

--- a/app/src/main/java/one/mixin/android/ui/wallet/DepositFragment.kt
+++ b/app/src/main/java/one/mixin/android/ui/wallet/DepositFragment.kt
@@ -48,6 +48,7 @@ import one.mixin.android.ui.conversation.ConversationActivity
 import one.mixin.android.ui.wallet.TransactionsFragment.Companion.ARGS_ASSET
 import one.mixin.android.ui.web.refreshScreenshot
 import one.mixin.android.util.ErrorHandler.Companion.ADDRESS_GENERATING
+import one.mixin.android.util.analytics.AnalyticsTracker
 import one.mixin.android.util.getChainName
 import one.mixin.android.vo.safe.DepositEntry
 import one.mixin.android.vo.safe.TokenItem
@@ -95,6 +96,7 @@ class DepositFragment : BaseFragment() {
     }
 
     override fun onDestroyView() {
+        AnalyticsTracker.trackAssetReceiveEnd()
         super.onDestroyView()
         _binding = null
     }
@@ -173,6 +175,7 @@ class DepositFragment : BaseFragment() {
                         }
                         setOnClickListener {
                             if (same) return@setOnClickListener
+                            AnalyticsTracker.trackAssetReceiveTokenSelect(AnalyticsTracker.TradeTokenSelectMethod.CHAIN_ITEM_CLICK)
                             syncJob?.cancel()
                             syncJob =
                                 lifecycleScope.launch {

--- a/app/src/main/java/one/mixin/android/ui/wallet/InputFragment.kt
+++ b/app/src/main/java/one/mixin/android/ui/wallet/InputFragment.kt
@@ -240,6 +240,7 @@ class InputFragment : BaseFragment(R.layout.fragment_input), OnReceiveSelectionC
         savedInstanceState: Bundle?,
     ) {
         super.onViewCreated(view, savedInstanceState)
+        AnalyticsTracker.trackAssetSendAmount()
         jobManager.addJobInBackground(SyncOutputJob())
         viewLifecycleOwner.lifecycleScope.launch {
             binding.apply {
@@ -1163,6 +1164,7 @@ class InputFragment : BaseFragment(R.layout.fragment_input), OnReceiveSelectionC
 
     private fun handleSuccessfulWeb3Transfer() {
         if (!isAdded) return
+        AnalyticsTracker.trackAssetSendEnd()
         val navController = findNavController()
         val backStackEntryCount = parentFragmentManager.backStackEntryCount
         val currentDestination = navController.currentDestination?.id
@@ -1882,6 +1884,7 @@ class InputFragment : BaseFragment(R.layout.fragment_input), OnReceiveSelectionC
                 val fee = requireNotNull(currentFee) { "withdrawal currentFee can not be null" }
                 t.fee = fee
             }
+            AnalyticsTracker.trackAssetSendPreview()
             TransferBottomSheetDialogFragment.newInstance(t).apply {
                 setCallback(object : TransferBottomSheetDialogFragment.Callback() {
                     override fun onDismiss(success: Boolean) {

--- a/app/src/main/java/one/mixin/android/ui/wallet/MarketDetailsFragment.kt
+++ b/app/src/main/java/one/mixin/android/ui/wallet/MarketDetailsFragment.kt
@@ -192,7 +192,6 @@ class MarketDetailsFragment : BaseFragment(R.layout.fragment_details_market) {
                 swapAlert.setAlertTitle(R.string.Alert)
                 swapAlert.alertVa.setOnClickListener {
                     if (NotificationManagerCompat.from(requireContext()).areNotificationsEnabled()) {
-                        AnalyticsTracker.trackMarketPriceAlerts(AnalyticsTracker.MarketAlertsType.ONE)
                         viewLifecycleOwner.lifecycleScope.launch {
                             var coinItem = if (marketItem.coinId.isBlank()) {
                                 walletViewModel.simpleCoinItemByAssetId(marketItem.assetIds!!.first())

--- a/app/src/main/java/one/mixin/android/ui/wallet/TokenListBottomSheetDialogFragment.kt
+++ b/app/src/main/java/one/mixin/android/ui/wallet/TokenListBottomSheetDialogFragment.kt
@@ -43,6 +43,7 @@ import one.mixin.android.ui.common.MixinBottomSheetDialogFragment
 import one.mixin.android.ui.wallet.adapter.SearchAdapter
 import one.mixin.android.ui.wallet.adapter.WalletSearchCallback
 import one.mixin.android.ui.wallet.components.RecentTokens
+import one.mixin.android.util.analytics.AnalyticsTracker
 import one.mixin.android.util.viewBinding
 import one.mixin.android.vo.safe.TokenItem
 import one.mixin.android.widget.BottomSheet
@@ -233,6 +234,7 @@ class TokenListBottomSheetDialogFragment : MixinBottomSheetDialogFragment() {
                     ) {
                         binding.searchEt.hideKeyboard()
                         tokenItem?.let {
+                            trackTokenSelect()
                             if (asyncOnAsset != null) {
                                 asyncClick(it)
                             } else {
@@ -296,6 +298,11 @@ class TokenListBottomSheetDialogFragment : MixinBottomSheetDialogFragment() {
                         id = View.generateViewId()
                         setContent {
                             RecentTokens(false, key) {
+                                if (fromType == TYPE_FROM_RECEIVE) {
+                                    AnalyticsTracker.trackAssetReceiveTokenSelect(AnalyticsTracker.TradeTokenSelectMethod.RECENT_CLICK)
+                                } else if (fromType == TYPE_FROM_SEND || fromType == TYPE_FROM_TRANSFER) {
+                                    AnalyticsTracker.trackAssetSendTokenSelect(AnalyticsTracker.TradeTokenSelectMethod.RECENT_CLICK)
+                                }
                                 defaultSharedPreferences.addToList(key, it.assetId)
                                 if (asyncOnAsset != null) {
                                     asyncClick(it)
@@ -387,6 +394,19 @@ class TokenListBottomSheetDialogFragment : MixinBottomSheetDialogFragment() {
                 if (!isAdded) return@launch
                 loadData()
             }
+    }
+
+    private fun trackTokenSelect() {
+        val method = when {
+            currentQuery.isNotBlank() -> AnalyticsTracker.TradeTokenSelectMethod.SEARCH_ITEM_CLICK
+            currentChain != null -> AnalyticsTracker.TradeTokenSelectMethod.CHAIN_ITEM_CLICK
+            else -> AnalyticsTracker.TradeTokenSelectMethod.ALL_ITEM_CLICK
+        }
+        if (fromType == TYPE_FROM_RECEIVE) {
+            AnalyticsTracker.trackAssetReceiveTokenSelect(method)
+        } else if (fromType == TYPE_FROM_SEND || fromType == TYPE_FROM_TRANSFER) {
+            AnalyticsTracker.trackAssetSendTokenSelect(method)
+        }
     }
 
     fun setOnAssetClick(callback: (TokenItem) -> Unit): TokenListBottomSheetDialogFragment {

--- a/app/src/main/java/one/mixin/android/ui/wallet/TransactionsFragment.kt
+++ b/app/src/main/java/one/mixin/android/ui/wallet/TransactionsFragment.kt
@@ -112,6 +112,7 @@ class TransactionsFragment : BaseFragment(R.layout.fragment_transactions), OnSna
         savedInstanceState: Bundle?,
     ) {
         super.onViewCreated(view, savedInstanceState)
+        AnalyticsTracker.trackAssetDetail(TradeWallet.MAIN, if (fromMarket) AnalyticsTracker.AssetSource.MARKET_DETAIL else AnalyticsTracker.AssetSource.WALLET_HOME)
         jobManager.addJobInBackground(CheckBalanceJob(arrayListOf(assetIdToAsset(asset.assetId))))
         jobManager.addJobInBackground(RefreshPriceJob(asset.assetId))
 
@@ -348,6 +349,7 @@ class TransactionsFragment : BaseFragment(R.layout.fragment_transactions), OnSna
         bottomBinding.apply {
             hide.setText(if (asset.hidden == true) R.string.Show else R.string.Hide)
             hide.setOnClickListener {
+                AnalyticsTracker.trackAssetDetailHide()
                 lifecycleScope.launch(Dispatchers.IO) {
                     walletViewModel.updateAssetHidden(asset.assetId, asset.hidden != true)
                 }
@@ -361,6 +363,7 @@ class TransactionsFragment : BaseFragment(R.layout.fragment_transactions), OnSna
     }
 
     override fun <T> onNormalItemClick(item: T) {
+        AnalyticsTracker.trackTransactionDetail(AnalyticsTracker.AssetSource.ASSET_DETAIL)
         view?.navigate(
             R.id.action_transactions_fragment_to_transaction_fragment,
             Bundle().apply {
@@ -388,6 +391,7 @@ class TransactionsFragment : BaseFragment(R.layout.fragment_transactions), OnSna
     }
 
     override fun onMoreClick() {
+        AnalyticsTracker.trackAllTransactions(AnalyticsTracker.AssetSource.ASSET_DETAIL)
         view?.navigate(
             R.id.action_transactions_fragment_to_all_transactions_fragment,
             Bundle().apply {
@@ -397,6 +401,7 @@ class TransactionsFragment : BaseFragment(R.layout.fragment_transactions), OnSna
     }
 
     private fun navigateToTransferDestination(asset: TokenItem) {
+        AnalyticsTracker.trackAssetSendStart(TradeWallet.MAIN, AnalyticsTracker.AssetSource.ASSET_DETAIL)
         findNavController().navigate(
             R.id.action_transactions_to_transfer_destination,
             Bundle().apply {
@@ -421,6 +426,7 @@ class TransactionsFragment : BaseFragment(R.layout.fragment_transactions), OnSna
             sendReceiveView.receive.setOnClickListener {
                 if (
                     showRecoveryReminderForRiskAction {
+                        AnalyticsTracker.trackAssetReceiveStart(AnalyticsTracker.AssetSource.ASSET_DETAIL, TradeWallet.MAIN)
                         sendReceiveView.navigate(
                             R.id.action_transactions_to_deposit,
                             Bundle().apply { putParcelable(ARGS_ASSET, asset) },
@@ -429,6 +435,7 @@ class TransactionsFragment : BaseFragment(R.layout.fragment_transactions), OnSna
                 ) {
                     return@setOnClickListener
                 }
+                AnalyticsTracker.trackAssetReceiveStart(AnalyticsTracker.AssetSource.ASSET_DETAIL, TradeWallet.MAIN)
                 sendReceiveView.navigate(
                     R.id.action_transactions_to_deposit,
                     Bundle().apply { putParcelable(ARGS_ASSET, asset) },

--- a/app/src/main/java/one/mixin/android/ui/wallet/WalletSearchFragment.kt
+++ b/app/src/main/java/one/mixin/android/ui/wallet/WalletSearchFragment.kt
@@ -34,6 +34,7 @@ import one.mixin.android.ui.wallet.TransactionsFragment.Companion.ARGS_ASSET
 import one.mixin.android.ui.wallet.adapter.SearchAdapter
 import one.mixin.android.ui.wallet.adapter.SearchDefaultAdapter
 import one.mixin.android.ui.wallet.adapter.WalletSearchCallback
+import one.mixin.android.util.analytics.AnalyticsTracker
 import one.mixin.android.vo.safe.TokenItem
 import java.util.concurrent.TimeUnit
 
@@ -235,6 +236,7 @@ class WalletSearchFragment : BaseFragment() {
                 assetId: String,
                 tokenItem: TokenItem?,
             ) {
+                AnalyticsTracker.trackSearchItemSelect(AnalyticsTracker.SearchItemType.ASSET, AnalyticsTracker.SearchSource.WALLET)
                 binding.searchEt.hideKeyboard()
                 if (tokenItem != null) {
                     view?.navigate(

--- a/app/src/main/java/one/mixin/android/ui/wallet/transfer/TransferBottomSheetDialogFragment.kt
+++ b/app/src/main/java/one/mixin/android/ui/wallet/transfer/TransferBottomSheetDialogFragment.kt
@@ -75,6 +75,7 @@ import one.mixin.android.ui.wallet.transfer.data.TransferStatus
 import one.mixin.android.ui.wallet.transfer.data.TransferType
 import one.mixin.android.util.BiometricUtil
 import one.mixin.android.util.ErrorHandler
+import one.mixin.android.util.analytics.AnalyticsTracker
 import one.mixin.android.util.getMixinErrorStringByCode
 import one.mixin.android.util.msg
 import one.mixin.android.util.viewBinding
@@ -724,6 +725,16 @@ class TransferBottomSheetDialogFragment : MixinBottomSheetDialogFragment() {
                     )
                     context?.updatePinCheck()
                     isSuccess = true
+                    when (t) {
+                        is AddressManageBiometricItem -> {
+                            if (t.type == ADD) {
+                                AnalyticsTracker.trackAddressBookAddEnd()
+                            }
+                        }
+                        is TransferBiometricItem, is AddressTransferBiometricItem, is WithdrawBiometricItem -> {
+                            AnalyticsTracker.trackAssetSendEnd()
+                        }
+                    }
 
                     val transactionHash = runCatching {
                         val data = response.data as? List<TransactionResponse>

--- a/app/src/main/java/one/mixin/android/util/analytics/AnalyticsTracker.kt
+++ b/app/src/main/java/one/mixin/android/util/analytics/AnalyticsTracker.kt
@@ -128,6 +128,179 @@ object AnalyticsTracker {
         firebaseAnalytics.setUserProperty("asset_level", level)
     }
 
+    fun trackAssetDetail(wallet: String, source: String) {
+        logEvent("asset_detail") {
+            putString("wallet", wallet)
+            putString("source", source)
+        }
+    }
+
+    fun trackAssetDetailHide() {
+        logEvent("asset_detail_hide")
+    }
+
+    fun trackAllTransactions(source: String) {
+        logEvent("all_transactions") {
+            putString("source", source)
+        }
+    }
+
+    fun trackTransactionDetail(source: String) {
+        logEvent("transaction_detail") {
+            putString("source", source)
+        }
+    }
+
+    object AssetSource {
+        const val WALLET_HOME = "wallet_home"
+        const val ASSET_DETAIL = "asset_detail"
+        const val PROFILE = "profile"
+        const val MARKET_DETAIL = "market_detail"
+        const val TRANSACTION_DETAIL = "transaction_detail"
+        const val WALLET_SEARCH = "wallet_search"
+        const val CHAT_SEARCH = "chat_search"
+        const val MORE_SEARCH = "more_search"
+        const val HIDDEN_ASSETS = "hidden_assets"
+        const val ALL_TRANSACTIONS = "all_transactions"
+        const val SCHEMA = "schema"
+        const val CHAT = "chat"
+    }
+
+    fun trackAssetReceiveStart(source: String, wallet: String) {
+        logEvent("asset_receive_start") {
+            putString("source", source)
+            putString("wallet", wallet)
+        }
+    }
+
+    fun trackAssetReceiveTokenSelect(method: String) {
+        logEvent("asset_receive_token_select") {
+            putString("method", method)
+        }
+    }
+
+    fun trackAssetReceiveEnd() {
+        logEvent("asset_receive_end")
+    }
+
+    fun trackAssetSendStart(wallet: String, source: String) {
+        logEvent("asset_send_start") {
+            putString("wallet", wallet)
+            putString("source", source)
+        }
+    }
+
+    fun trackAssetSendTokenSelect(method: String) {
+        logEvent("asset_send_token_select") {
+            putString("method", method)
+        }
+    }
+
+    fun trackAssetSendRecipient(type: String) {
+        logEvent("asset_send_recipient") {
+            putString("type", type)
+        }
+    }
+
+    fun trackAssetSendAmount() {
+        logEvent("asset_send_amount")
+    }
+
+    fun trackAssetSendPreview() {
+        logEvent("asset_send_preview")
+    }
+
+    fun trackAssetSendEnd() {
+        logEvent("asset_send_end")
+    }
+
+    object AssetSendRecipientType {
+        const val ADDRESS = "address"
+        const val WALLET = "wallet"
+        const val ADDRESS_BOOK = "address_book"
+        const val CONTACT = "contact"
+    }
+
+    fun trackAddressBookAddStart() {
+        logEvent("address_book_add_start")
+    }
+
+    fun trackAddressBookAddMemo(type: String) {
+        logEvent("address_book_add_memo") {
+            putString("type", type)
+        }
+    }
+
+    fun trackAddressBookAddLabel() {
+        logEvent("address_book_add_label")
+    }
+
+    fun trackAddressBookAddPreview() {
+        logEvent("address_book_add_preview")
+    }
+
+    fun trackAddressBookAddEnd() {
+        logEvent("address_book_add_end")
+    }
+
+    fun trackAccountResumePin(type: String) {
+        logEvent("account_resume_pin") {
+            putString("type", type)
+        }
+    }
+
+    object AccountResumePinType {
+        const val PIN_CREATE = "pin_create"
+        const val PIN_CHANGE = "pin_change"
+    }
+
+    fun trackHomeTabSwitch(method: String) {
+        logEvent("home_tab_switch") {
+            putString("method", method)
+        }
+    }
+
+    object HomeTabMethod {
+        const val CHATS = "chats"
+        const val WALLETS = "wallets"
+        const val COLLECTIBLES = "collectibles"
+        const val MORE = "more"
+    }
+
+    fun trackMoreTabSwitch(method: String) {
+        logEvent("more_tab_switch") {
+            putString("method", method)
+        }
+    }
+
+    object MoreTabMethod {
+        const val BOTS = "bots"
+        const val MARKETS = "markets"
+    }
+
+    fun trackSearchItemSelect(type: String, source: String) {
+        logEvent("search_item_select") {
+            putString("type", type)
+            putString("source", source)
+        }
+    }
+
+    object SearchItemType {
+        const val CONTACT = "contact"
+        const val CONVERSATION = "conversation"
+        const val MESSAGES = "messages"
+        const val ASSET = "asset"
+        const val BOT = "bot"
+        const val LINK = "link"
+        const val PHONE = "phone"
+    }
+
+    object SearchSource {
+        const val CHAT = "chat"
+        const val WALLET = "wallet"
+        const val MORE = "more"
+    }
+
     fun trackTradeTokenSelect(method: String) {
         logEvent("trade_token_select") {
             putString("method", method)

--- a/app/src/main/java/one/mixin/android/util/analytics/AnalyticsTracker.kt
+++ b/app/src/main/java/one/mixin/android/util/analytics/AnalyticsTracker.kt
@@ -293,7 +293,7 @@ object AnalyticsTracker {
         const val MORE_MARKET_CAP = "more_market_cap"
         const val MORE_FAVORITES = "more_favorites"
         const val MORE_SEARCH = "more_search"
-        const val TOKEN_DETAIL = "token_detal"
+        const val TOKEN_DETAIL = "token_detail"
         const val APP_CARD = "app_card"
         const val SCHEMA = "schema"
         const val MARKET_DETAIL = "market_detail"

--- a/app/src/main/java/one/mixin/android/util/analytics/AnalyticsTracker.kt
+++ b/app/src/main/java/one/mixin/android/util/analytics/AnalyticsTracker.kt
@@ -97,8 +97,8 @@ object AnalyticsTracker {
         logEvent("login_end")
     }
 
-    fun setHasEmergencyContact(account: Account) {
-        firebaseAnalytics.setUserProperty("has_emergency_contact", account.hasEmergencyContact.toString())
+    fun setHasRecoveryContact(account: Account) {
+        firebaseAnalytics.setUserProperty("has_recovery_contact", account.hasEmergencyContact.toString())
     }
 
     fun setMembership(account: Account) {
@@ -106,19 +106,21 @@ object AnalyticsTracker {
     }
 
     fun setNotificationAuthStatus(context: Context) {
-        firebaseAnalytics.setUserProperty(
-            "notification_auth_status", if (NotificationManagerCompat.from(context).areNotificationsEnabled()) {
-                "authorized"
-            } else {
-                "denied"
-            }
-        )
+        val status = if (NotificationManagerCompat.from(context).areNotificationsEnabled()) {
+            "authorized"
+        } else {
+            "denied"
+        }
+        firebaseAnalytics.setUserProperty("notification_auth_status", status)
     }
 
     fun setAssetLevel(totalUsd: Int) {
         val level = when {
-            totalUsd >= 10000 -> "v10000"
-            totalUsd >= 1000 -> "v1000"
+            totalUsd >= 10000000 -> "v10,000,000"
+            totalUsd >= 1000000 -> "v1,000,000"
+            totalUsd >= 100000 -> "v100,000"
+            totalUsd >= 10000 -> "v10,000"
+            totalUsd >= 1000 -> "v1,000"
             totalUsd >= 100 -> "v100"
             totalUsd >= 1 -> "v1"
             else -> "v0"

--- a/app/src/main/java/one/mixin/android/util/analytics/AnalyticsTracker.kt
+++ b/app/src/main/java/one/mixin/android/util/analytics/AnalyticsTracker.kt
@@ -323,6 +323,8 @@ object AnalyticsTracker {
         const val PERPS_MARKET_DETAIL = "perps_market_detail"
         const val PERPS_ALL_POSITIONS = "perps_all_positions"
         const val PERPS_ACTIVITY_DETAIL = "perps_activity_detail"
+        const val PERPS_HOME_LIST = "perps_home_list"
+        const val PERPS_ACTIVITY_LIST = "perps_activity_list"
     }
 
     object PerpsDirection {


### PR DESCRIPTION
- Implement reporting for has_recovery_contact, membership, notification_auth_status, and asset_level.
- Rename has_emergency_contact to has_recovery_contact in AnalyticsTracker.
- Update asset_level values with comma formatting and higher tiers.
- Report properties on app open in ConversationListFragment.
- Report properties after successful recovery contact changes and notification permission grants.
- Optimize asset_level reporting by moving it to RefreshTokensJob and RefreshAssetsJob to ensure accuracy after DB updates.