### PR TITLE
fix(perps): always display amounts in USD without fiat conversion

### DIFF
--- a/app/src/main/java/one/mixin/android/ui/home/web3/trade/perps/AllPositionsPage.kt
+++ b/app/src/main/java/one/mixin/android/ui/home/web3/trade/perps/AllPositionsPage.kt
@@ -58,7 +58,6 @@ import one.mixin.android.extension.defaultSharedPreferences
 import one.mixin.android.session.Session
 import one.mixin.android.ui.home.web3.components.PageScaffold
 import one.mixin.android.ui.wallet.alert.components.cardBackground
-import one.mixin.android.vo.Fiats
 import java.math.BigDecimal
 import java.math.RoundingMode
 
@@ -399,7 +398,7 @@ private fun TotalPositionValueCard(
         )
         Spacer(modifier = Modifier.height(6.dp))
         Text(
-            text = formatPerpsFiatDecimal(totalMargin.abs().multiply(BigDecimal(Fiats.getRate())), Fiats.getSymbol()),
+            text = formatPerpsUsdDecimal(totalMargin.abs()),
             fontSize = 18.sp,
             fontWeight = FontWeight.W500,
             color = MixinAppTheme.colors.textPrimary,

--- a/app/src/main/java/one/mixin/android/ui/home/web3/trade/perps/OpenPositionItem.kt
+++ b/app/src/main/java/one/mixin/android/ui/home/web3/trade/perps/OpenPositionItem.kt
@@ -36,7 +36,6 @@ import one.mixin.android.compose.CoilImage
 import one.mixin.android.compose.theme.MixinAppTheme
 import one.mixin.android.extension.colorAttr
 import one.mixin.android.extension.defaultSharedPreferences
-import one.mixin.android.vo.Fiats
 import java.math.BigDecimal
 
 @Composable
@@ -48,8 +47,6 @@ fun OpenPositionItem(
     val quoteColorPref = context.defaultSharedPreferences
         .getBoolean(Constants.Account.PREF_QUOTE_COLOR, false)
     val margin = position.margin?.toBigDecimalOrNull() ?: BigDecimal.ZERO
-    val fiatRate = BigDecimal(Fiats.getRate())
-    val fiatSymbol = Fiats.getSymbol()
 
     val displaySymbol = position.tokenSymbol ?: stringResource(R.string.Unknown)
     val quantity = position.quantity

--- a/app/src/main/java/one/mixin/android/ui/home/web3/trade/perps/PerpsConfirmBottomSheetDialogFragment.kt
+++ b/app/src/main/java/one/mixin/android/ui/home/web3/trade/perps/PerpsConfirmBottomSheetDialogFragment.kt
@@ -82,7 +82,6 @@ import one.mixin.android.ui.wallet.ItemUserContent
 import one.mixin.android.ui.wallet.components.WalletLabel
 import one.mixin.android.util.SystemUIManager
 import one.mixin.android.util.analytics.AnalyticsTracker
-import one.mixin.android.vo.Fiats
 import one.mixin.android.vo.User
 import one.mixin.android.vo.toUser
 import one.mixin.android.widget.components.MixinButton
@@ -181,8 +180,6 @@ class PerpsConfirmBottomSheetDialogFragment : MixinComposeBottomSheetDialogFragm
     private val takeProfitPrice by lazy { requireArguments().getString(ARGS_TAKE_PROFIT_PRICE).orEmpty() }
     private val stopLossPrice by lazy { requireArguments().getString(ARGS_STOP_LOSS_PRICE).orEmpty() }
     private val isAddPosition by lazy { requireArguments().getBoolean(ARGS_IS_ADD_POSITION) }
-    private val fiatRate by lazy { BigDecimal(Fiats.getRate()) }
-    private val fiatSymbol by lazy { Fiats.getSymbol() }
 
     private val payUrl by lazy { requireArguments().getString(ARGS_PAY_URL) }
     private val entryFiatPrice by lazy {

--- a/app/src/main/java/one/mixin/android/ui/home/web3/trade/perps/PositionDetailPage.kt
+++ b/app/src/main/java/one/mixin/android/ui/home/web3/trade/perps/PositionDetailPage.kt
@@ -53,7 +53,6 @@ import one.mixin.android.ui.home.web3.components.PageScaffold
 import one.mixin.android.ui.tip.wc.compose.ItemWalletContent
 import one.mixin.android.ui.wallet.alert.components.cardBackground
 import one.mixin.android.util.getMixinErrorStringByCode
-import one.mixin.android.vo.Fiats
 import org.threeten.bp.Instant
 import org.threeten.bp.ZoneId
 import org.threeten.bp.format.DateTimeFormatter
@@ -108,8 +107,6 @@ fun PositionDetailPage(
         ?.takeIf { it.isNotBlank() }
         ?.let { formatPerpsPrice(it, position.priceScale) }
         ?: "--"
-    val fiatRate = BigDecimal(Fiats.getRate())
-    val fiatSymbol = Fiats.getSymbol()
     val hasTakeProfit = !position.takeProfitPrice.isNullOrBlank()
     val hasStopLoss = !position.stopLossPrice.isNullOrBlank()
     var hideTakeProfitGuideUntil by remember(preferences) {
@@ -541,8 +538,6 @@ fun PositionDetailPage(
 
     val quantity = closeOrder.quantity.toBigDecimalOrNull() ?: BigDecimal.ZERO
     val absQuantity = quantity.abs()
-    val fiatRate = BigDecimal(Fiats.getRate())
-    val fiatSymbol = Fiats.getSymbol()
     val effectiveLeverage = leverage ?: closeOrder.leverage
     val roe = (closeOrder.roe.toBigDecimalOrNull() ?: BigDecimal.ZERO).multiply(BigDecimal(100))
 


### PR DESCRIPTION
Drop Fiats.getRate/getSymbol from the total position value card so the amount stays in USD, and clean up unused fiatRate/fiatSymbol leftovers in the confirm sheet, open position item, and position detail pages.