### PR TITLE
fix(market): show min/max markers on share chart

### DIFF
--- a/app/src/main/java/one/mixin/android/ui/home/market/LineChart.kt
+++ b/app/src/main/java/one/mixin/android/ui/home/market/LineChart.kt
@@ -73,8 +73,14 @@ private fun maxRange(): Float {
 }
 
 @Composable
-fun LineChart(dataPointsData: List<Float>, timePointsData: List<Long>? = null, type: String? = null, onHighlightChange: ((Int) -> Unit)? = null) {
-    val (dataPoints, minIndex, maxIndex) = normalizeValues(dataPointsData, normalizedMaxRange = if (onHighlightChange != null) null else 1f)
+fun LineChart(
+    dataPointsData: List<Float>,
+    timePointsData: List<Long>? = null,
+    type: String? = null,
+    onHighlightChange: ((Int) -> Unit)? = null,
+    showMinMaxMarkers: Boolean = onHighlightChange != null,
+) {
+    val (dataPoints, minIndex, maxIndex) = normalizeValues(dataPointsData, normalizedMaxRange = if (showMinMaxMarkers) null else 1f)
     MixinAppTheme {
         val textPrimary = MixinAppTheme.colors.textPrimary
         val background = MixinAppTheme.colors.background
@@ -210,7 +216,7 @@ fun LineChart(dataPointsData: List<Float>, timePointsData: List<Long>? = null, t
                         color = color, radius = 8f, center = circleCenter
                     )
                 }
-                if (onHighlightChange != null && minIndex != -1 && maxIndex != -1) {
+                if (showMinMaxMarkers && minIndex != -1 && maxIndex != -1) {
                     val minCircleCenter = Offset(
                         minIndex * spacing, size.height * dataPoints[minIndex]
                     )
@@ -238,7 +244,7 @@ fun LineChart(dataPointsData: List<Float>, timePointsData: List<Long>? = null, t
                 }
             }
 
-            if (onHighlightChange != null && minIndex != -1 && maxIndex != -1) {
+            if (showMinMaxMarkers && minIndex != -1 && maxIndex != -1) {
                 val spacing = canvasSize.width / (dataPoints.size - 1)
                 val minXPosition = minIndex * spacing
                 val minYPosition = canvasSize.height * dataPoints[minIndex]

--- a/app/src/main/java/one/mixin/android/ui/home/market/Market.kt
+++ b/app/src/main/java/one/mixin/android/ui/home/market/Market.kt
@@ -156,7 +156,7 @@ fun Market(
                     } else {
                         null
                     }
-                    LineChart(prices, time, type, highlightChange)
+                    LineChart(prices, time, type, highlightChange, showMinMaxMarkers = true)
                 }
             }
 

--- a/app/src/main/res/layout/item_perps_position_share_poster.xml
+++ b/app/src/main/res/layout/item_perps_position_share_poster.xml
@@ -146,7 +146,7 @@
                     android:layout_marginTop="2dp"
                     android:includeFontPadding="false"
                     android:textColor="@color/white"
-                    android:textSize="13sp"
+                    android:textSize="14sp"
                     android:textFontWeight="600"
                     tools:text="$45,328.6" />
 
@@ -167,7 +167,7 @@
                     android:layout_marginTop="2dp"
                     android:includeFontPadding="false"
                     android:textColor="@color/white"
-                    android:textSize="13sp"
+                    android:textSize="14sp"
                     android:textFontWeight="600"
                     tools:text="$3,412.23" />
             </LinearLayout>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -2267,7 +2267,6 @@
     <string name="example_scene2_decreasing">场景二：价格下跌</string>
     <string name="example_scene2_increasing">场景二：价格上涨</string>
     <string name="PnL">盈亏</string>
-    <string name="RoE">收益率</string>
     <string name="perps_long_overview">做多是指在预期价格上涨时建立仓位，价格上涨可获得盈利，价格下跌则产生亏损。</string>
     <string name="perps_short_overview">做空是指在预期价格下跌时建立仓位，价格下跌可获得盈利，价格上涨则产生亏损。</string>
     <string name="pnl_rule_price_fall_loss">价格下跌：产生亏损</string>
@@ -2498,8 +2497,8 @@
     <string name="pin_log_subtitle_mnemonic_phrase_exported">✅ 助记词已导出</string>
     <string name="pin_log_subtitle_mobile_number_changed">✅ 手机号已修改</string>
     <string name="perps_share_to_mixin_contact">发送到 Mixin 联系人</string>
-    <string name="perps_share_pnl">收益额</string>
-    <string name="perps_share_roe">收益率</string>
+    <string name="perps_share_pnl">收益率</string>
+    <string name="perps_share_roe">收益额</string>
     <string name="perps_share_mixin_contact_desc">邀请好友一起交易</string>
     <string name="perps_share_mixin_contact_desc_with_percent">通过此链接赚取 %1$s 分佣</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2338,7 +2338,6 @@
     <string name="example_scene2_decreasing">Scenario 2: Price Falls</string>
     <string name="example_scene2_increasing">Scenario 2: Price Rises</string>
     <string name="PnL">PnL</string>
-    <string name="RoE">RoE</string>
     <string name="perps_long_overview">You open a long position when you expect the price to rise. If the price rises, you profit; if the price falls, you incur a loss.</string>
     <string name="perps_short_overview">You open a short position when you expect the price to fall. If the price falls, you profit; if the price rises, you incur a loss.</string>
     <string name="pnl_rule_price_fall_loss">Price falls, loss</string>


### PR DESCRIPTION
Decouple min/max marker rendering from gesture handling so the non-interactive share chart shows high/low circles and labels just like the details page.

Also bump entry/latest price font size on the perps position share poster from 13sp to 14sp for better legibility.