### PR TITLE
fix(search): require .mao suffix in isValidMao to reduce search API c…

### DIFF
--- a/app/src/main/java/one/mixin/android/extension/StringExtension.kt
+++ b/app/src/main/java/one/mixin/android/extension/StringExtension.kt
@@ -823,10 +823,12 @@ fun BigDecimal.currencyFormat(): String {
 
 fun String?.isValidMao(): Boolean {
     if (this.isNullOrBlank()) return false
-    val text = this.trimEnd('.').lowercase()
-    if (text.all { it.isDigit() }) return false
-    val regex = Regex("^[^\\sA-Z]{1,128}$")
-    return regex.matches(text)
+    val text = this.lowercase()
+    val regex = Regex("^[^\\sA-Z]{1,128}\\.mao$")
+    if (!regex.matches(text)) return false
+    val name = text.removeSuffix(".mao")
+    if (name.isBlank() || name.all { it.isDigit() }) return false
+    return true
 }
 
 fun String.isMao(): Boolean {


### PR DESCRIPTION
…alls

The previous regex only excluded whitespace and uppercase, so almost any typed keyword (e.g. 'hello', 'abc', 'a') triggered the MAO user lookup API and risked rate limiting / bans. Tighten isValidMao to match the MAO domain pattern (^[^\sA-Z]{1,128}\.mao$) and reject pure-digit names, so the API is only hit when the keyword actually looks like a MAO domain.