### PR TITLE
fix(perps): add liquidation price loading and retry

### DIFF
--- a/app/src/main/java/one/mixin/android/api/response/perps/MarketLiquidationPriceView.kt
+++ b/app/src/main/java/one/mixin/android/api/response/perps/MarketLiquidationPriceView.kt
@@ -1,0 +1,8 @@
+package one.mixin.android.api.response.perps
+
+import com.google.gson.annotations.SerializedName
+
+data class MarketLiquidationPriceView(
+    @SerializedName("liquidation_price")
+    val liquidationPrice: String? = null,
+)

--- a/app/src/main/java/one/mixin/android/api/service/RouteService.kt
+++ b/app/src/main/java/one/mixin/android/api/service/RouteService.kt
@@ -34,6 +34,7 @@ import one.mixin.android.api.response.RouteOrderResponse
 import one.mixin.android.api.response.RouteTickerResponse
 import one.mixin.android.api.response.UserAddressView
 import one.mixin.android.api.response.perps.CandleView
+import one.mixin.android.api.response.perps.MarketLiquidationPriceView
 import one.mixin.android.api.response.perps.PerpsMarket
 import one.mixin.android.api.response.perps.PerpsOrder
 import one.mixin.android.api.response.perps.PerpsPosition
@@ -395,6 +396,15 @@ interface RouteService {
         @Query("market_id") marketId: String,
         @Query("time_frame") timeFrame: String
     ): MixinResponse<CandleView>
+
+    @GET("perps/markets/liquidation-price")
+    suspend fun getPerpsLiquidationPrice(
+        @Query("market_id") marketId: String? = null,
+        @Query("amount") amount: String,
+        @Query("side") side: String? = null,
+        @Query("leverage") leverage: Int? = null,
+        @Query("position_id") positionId: String? = null,
+    ): MixinResponse<MarketLiquidationPriceView>
 
     @GET("perps/orders/accepted-assets")
     suspend fun getAcceptedAssets(): MixinResponse<List<String>>

--- a/app/src/main/java/one/mixin/android/ui/home/web3/trade/perps/OpenPositionPage.kt
+++ b/app/src/main/java/one/mixin/android/ui/home/web3/trade/perps/OpenPositionPage.kt
@@ -22,6 +22,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
@@ -51,6 +52,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.fragment.app.FragmentActivity
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import one.mixin.android.Constants
@@ -144,9 +146,12 @@ fun OpenPositionPage(
     var usdtAmount by remember { mutableStateOf("") }
     var takeProfitPrice by remember { mutableStateOf("") }
     var stopLossPrice by remember { mutableStateOf("") }
+    var remoteLiquidationPrice by remember { mutableStateOf<String?>(null) }
+    var isLiquidationLoading by remember { mutableStateOf(false) }
     var errorInfo by remember { mutableStateOf<String?>(null) }
     var isProcessing by remember { mutableStateOf(false) }
     val scope = rememberCoroutineScope()
+    var liquidationJob by remember { mutableStateOf<Job?>(null) }
 
     val savedLeverage = remember(marketId) {
         context.defaultSharedPreferences
@@ -213,6 +218,34 @@ fun OpenPositionPage(
         }
     }
 
+    LaunchedEffect(usdtAmount, leverage) {
+        val amount = usdtAmount.toBigDecimalOrNull()
+        if (amount == null || amount <= BigDecimal.ZERO) {
+            remoteLiquidationPrice = null
+            isLiquidationLoading = false
+            return@LaunchedEffect
+        }
+        liquidationJob?.cancel()
+        liquidationJob = launch {
+            isLiquidationLoading = true
+            delay(200L)
+            while (true) {
+                val result = viewModel.estimateLiquidationPrice(
+                    marketId = currentMarket.marketId,
+                    amount = amount.stripTrailingZeros().toPlainString(),
+                    side = if (isLong) "long" else "short",
+                    leverage = leverage.toInt(),
+                )
+                if (result != null) {
+                    remoteLiquidationPrice = result
+                    isLiquidationLoading = false
+                    break
+                }
+                delay(1000L)
+            }
+        }
+    }
+
     val leverageOptions = generateLeverageOptions(maxLeverage)
     val inputAmount = usdtAmount.toBigDecimalOrNull()
     val tokenBalance = currentToken?.balance?.toBigDecimalOrNull() ?: BigDecimal.ZERO
@@ -223,7 +256,7 @@ fun OpenPositionPage(
     val aboveMaximumMargin = hasInputAmount && maximumMargin > BigDecimal.ZERO && inputAmount > maximumMargin
     val insufficientBalance = hasInputAmount && inputAmount > tokenBalance
     val showAddAction = insufficientBalance || tokenBalance <= BigDecimal.ZERO
-    val canReview = hasInputAmount && !belowMinimumMargin && !aboveMaximumMargin && !insufficientBalance
+    val canReview = hasInputAmount && !belowMinimumMargin && !aboveMaximumMargin && !insufficientBalance && !isLiquidationLoading
     val minimumMarginError = stringResource(
         R.string.perps_minimum_margin,
         minimumMargin.stripTrailingZeros().toPlainString(),
@@ -234,6 +267,12 @@ fun OpenPositionPage(
         maximumMargin.stripTrailingZeros().toPlainString(),
         currentToken?.symbol.orEmpty(),
     )
+    val localLiquidationPrice = calculateLiquidationPrice(
+        currentMarket.last,
+        leverage,
+        isLong,
+    )
+    val displayLiquidationPrice = remoteLiquidationPrice ?: localLiquidationPrice
     val marginLimitError = when {
         belowMinimumMargin -> minimumMarginError
         aboveMaximumMargin -> maximumMarginError
@@ -640,11 +679,8 @@ fun OpenPositionPage(
                     Spacer(modifier = Modifier.height(16.dp))
                     PerpsInfoRow(
                         title = stringResource(R.string.Liquidation_Price),
-                        value = calculateLiquidationPrice(
-                            currentMarket.last,
-                            leverage,
-                            isLong,
-                        ),
+                        value = displayLiquidationPrice?.let { formatPerpsPrice(it, currentMarket.priceScale) } ?: "--",
+                        isLoading = isLiquidationLoading,
                         onTipClick = {
                             showPerpsGuide(PerpetualGuideBottomSheetDialogFragment.TAB_LIQUIDATION)
                         },
@@ -732,6 +768,8 @@ fun OpenPositionPage(
                                         tokenSymbol = token.symbol,
                                         takeProfitPrice = takeProfitPrice.takeIf { it.isNotBlank() },
                                         stopLossPrice = stopLossPrice.takeIf { it.isNotBlank() },
+                                        liquidationPrice = displayLiquidationPrice,
+                                        priceScale = m.priceScale,
                                         payUrl = response.paymentUrl
                                     ).setOnDone {
                                             onOpenSuccess(m.marketId)
@@ -902,22 +940,19 @@ private fun calculateLiquidationPrice(
     currentPrice: String,
     leverage: Float,
     isLong: Boolean,
-): String {
-    val price = currentPrice.toBigDecimalOrNull() ?: BigDecimal.ZERO
-
-
-    if (price == BigDecimal.ZERO) {
-        return formatPerpsUsdDecimal(BigDecimal.ZERO)
+): String? {
+    val price = currentPrice.toBigDecimalOrNull() ?: return null
+    if (price <= BigDecimal.ZERO || leverage <= 0f) {
+        return null
     }
 
-    val liquidationPercent = BigDecimal(100.0 / leverage)
-    val liquidationRatio = liquidationPercent.divide(BigDecimal(100), 8, RoundingMode.HALF_UP)
+    val liquidationRatio = BigDecimal.ONE.divide(BigDecimal(leverage.toDouble()), 8, RoundingMode.HALF_UP)
     val liquidationPrice = if (isLong) {
         price * (BigDecimal.ONE - liquidationRatio)
     } else {
         price * (BigDecimal.ONE + liquidationRatio)
     }
-    return formatPerpsUsdDecimal(liquidationPrice)
+    return liquidationPrice.stripTrailingZeros().toPlainString()
 }
 
 private fun formatPerpsPrice(
@@ -983,6 +1018,7 @@ private fun PerpsActionRow(
 private fun PerpsInfoRow(
     title: String,
     value: String,
+    isLoading: Boolean = false,
     onTipClick: (() -> Unit)? = null,
 ) {
     Row(
@@ -1012,11 +1048,19 @@ private fun PerpsInfoRow(
                 )
             }
         }
-        Text(
-            text = value,
-            fontSize = 14.sp,
-            color = MixinAppTheme.colors.textAssist,
-            textAlign = TextAlign.End,
-        )
+        if (isLoading) {
+            CircularProgressIndicator(
+                modifier = Modifier.size(16.dp),
+                strokeWidth = 2.dp,
+                color = MixinAppTheme.colors.textAssist,
+            )
+        } else {
+            Text(
+                text = value,
+                fontSize = 14.sp,
+                color = MixinAppTheme.colors.textAssist,
+                textAlign = TextAlign.End,
+            )
+        }
     }
 }

--- a/app/src/main/java/one/mixin/android/ui/home/web3/trade/perps/PerpetualViewModel.kt
+++ b/app/src/main/java/one/mixin/android/ui/home/web3/trade/perps/PerpetualViewModel.kt
@@ -289,6 +289,35 @@ class PerpetualViewModel @Inject constructor(
         }
     }
 
+    suspend fun estimateLiquidationPrice(
+        amount: String,
+        marketId: String? = null,
+        side: String? = null,
+        leverage: Int? = null,
+        positionId: String? = null,
+    ): String? {
+        return try {
+            val response = withContext(Dispatchers.IO) {
+                routeService.getPerpsLiquidationPrice(
+                    marketId = marketId,
+                    amount = amount,
+                    side = side,
+                    leverage = leverage,
+                    positionId = positionId,
+                )
+            }
+            if (response.isSuccess) {
+                response.data?.liquidationPrice?.takeIf { it.isNotBlank() }
+            } else {
+                Timber.e("Failed to estimate liquidation price: ${response.errorDescription}")
+                null
+            }
+        } catch (e: Exception) {
+            Timber.e(e, "Error estimating liquidation price")
+            null
+        }
+    }
+
     fun loadUsdTokens(onSuccess: (List<TokenItem>) -> Unit) {
         viewModelScope.launch {
             try {

--- a/app/src/main/java/one/mixin/android/ui/home/web3/trade/perps/PerpsAddBottomSheetDialogFragment.kt
+++ b/app/src/main/java/one/mixin/android/ui/home/web3/trade/perps/PerpsAddBottomSheetDialogFragment.kt
@@ -27,6 +27,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.Icon
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
@@ -55,7 +56,9 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import one.mixin.android.Constants
 import one.mixin.android.R
 import one.mixin.android.api.response.perps.PerpsMarket
@@ -112,10 +115,10 @@ class PerpsAddBottomSheetDialogFragment : MixinComposeBottomSheetDialogFragment(
         requireArguments().getParcelableCompat(ARGS_POSITION, PerpsPositionItem::class.java)!!
     }
 
-    private var onAddAction: ((TokenItem, String) -> Unit)? = null
+    private var onAddAction: ((TokenItem, String, String?) -> Unit)? = null
     private var onDestroyAction: (() -> Unit)? = null
 
-    fun setOnAdd(callback: (TokenItem, String) -> Unit): PerpsAddBottomSheetDialogFragment {
+    fun setOnAdd(callback: (TokenItem, String, String?) -> Unit): PerpsAddBottomSheetDialogFragment {
         onAddAction = callback
         return this
     }
@@ -217,9 +220,9 @@ class PerpsAddBottomSheetDialogFragment : MixinComposeBottomSheetDialogFragment(
                     }.show(parentFragmentManager, TokenListBottomSheetDialogFragment.TAG)
                 },
                 onCancel = { dismiss() },
-                onAdd = { token, amount ->
+                onAdd = { token, amount, liquidationPrice ->
                     onAddAction?.let { action ->
-                        action(token, amount)
+                        action(token, amount, liquidationPrice)
                         dismiss()
                     }
                 },
@@ -246,13 +249,17 @@ private fun PerpsAddContent(
     selectedToken: TokenItem?,
     onTokenSelect: () -> Unit,
     onCancel: () -> Unit,
-    onAdd: (TokenItem, String) -> Unit,
+    onAdd: (TokenItem, String, String?) -> Unit,
 ) {
     val context = LocalContext.current
     val density = LocalDensity.current
     val keyboardController = LocalSoftwareKeyboardController.current
     val focusManager = LocalFocusManager.current
+    val viewModel = hiltViewModel<PerpetualViewModel>()
     var amount by remember(position.positionId) { mutableStateOf("") }
+    var remoteLiquidationPrice by remember(position.positionId) { mutableStateOf<String?>(null) }
+    var isLiquidationLoading by remember(position.positionId) { mutableStateOf(false) }
+    var liquidationJob by remember(position.positionId) { mutableStateOf<Job?>(null) }
     val tokenBalance = selectedToken?.balance?.toBigDecimalOrNull() ?: BigDecimal.ZERO
     val amountValue = amount.toBigDecimalOrNull()
     val hasInputAmount = amountValue != null && amountValue > BigDecimal.ZERO
@@ -263,13 +270,37 @@ private fun PerpsAddContent(
     val aboveMaximumMargin = amountValue != null && maximumMargin > BigDecimal.ZERO && amountValue > maximumMargin
 
     val insufficientBalance = amountValue != null && amountValue > BigDecimal.ZERO && amountValue > tokenBalance
-    val canAdd = selectedToken != null && hasInputAmount && !insufficientBalance && !belowMinimumMargin && !aboveMaximumMargin
+    val canAdd = selectedToken != null && hasInputAmount && !insufficientBalance && !belowMinimumMargin && !aboveMaximumMargin && !isLiquidationLoading
     val marketSymbol = position.tokenSymbol ?: position.displaySymbol.orEmpty()
     val currentPrice = market?.last.orEmpty()
         .ifBlank { market?.markPrice.orEmpty() }
         .ifBlank { position.markPrice.orEmpty() }
         .ifBlank { position.entryPrice }
     val priceScale = market?.priceScale ?: position.priceScale
+
+    LaunchedEffect(amount) {
+        val addMargin = amount.toBigDecimalOrNull()
+        if (addMargin == null || addMargin <= BigDecimal.ZERO) {
+            return@LaunchedEffect
+        }
+        liquidationJob?.cancel()
+        liquidationJob = launch {
+            isLiquidationLoading = true
+            delay(200L)
+            while (true) {
+                val result = viewModel.estimateLiquidationPrice(
+                    amount = addMargin.stripTrailingZeros().toPlainString(),
+                    positionId = position.positionId,
+                )
+                if (result != null) {
+                    remoteLiquidationPrice = result
+                    isLiquidationLoading = false
+                    break
+                }
+                delay(1000L)
+            }
+        }
+    }
 
     val minimumMarginError = stringResource(
         R.string.perps_minimum_margin,
@@ -288,6 +319,7 @@ private fun PerpsAddContent(
     }
 
     val currentPriceText = formatPerpsPrice(currentPrice, priceScale)
+    val displayLiquidationPrice = remoteLiquidationPrice
     val entryPriceText = position.entryPrice
         .takeIf { it.isNotBlank() }
         ?.let { formatPerpsPrice(it, priceScale) }
@@ -535,12 +567,8 @@ private fun PerpsAddContent(
                     Spacer(modifier = Modifier.height(16.dp))
                     PerpsAddInfoRow(
                         title = stringResource(R.string.Liquidation_Price),
-                        value = calculateEstimatedLiquidationPrice(
-                            position = position,
-                            amount = amount,
-                            currentPrice = currentPrice,
-                            priceScale = priceScale,
-                        ),
+                        value = displayLiquidationPrice?.let { formatPerpsPrice(it, priceScale) } ?: "--",
+                        isLoading = isLiquidationLoading,
                         onTipClick = {
                             showPerpsGuide(PerpetualGuideBottomSheetDialogFragment.TAB_LIQUIDATION)
                         },
@@ -559,13 +587,13 @@ private fun PerpsAddContent(
                         onAdd = {
                             val token = selectedToken ?: return@PerpsAddActionFooter
                             val normalizedAmount = amount.toBigDecimalOrNull()
-                                ?.stripTrailingZeros()
-                                ?.toPlainString()
-                                ?: return@PerpsAddActionFooter
-                            onAdd(token, normalizedAmount)
-                        },
-                    )
-                }
+                            ?.stripTrailingZeros()
+                            ?.toPlainString()
+                            ?: return@PerpsAddActionFooter
+                        onAdd(token, normalizedAmount, displayLiquidationPrice)
+                    },
+                )
+            }
             }
         },
         floating = {
@@ -596,7 +624,7 @@ private fun PerpsAddContent(
                             ?.stripTrailingZeros()
                             ?.toPlainString()
                             ?: return@PerpsAddActionFooter
-                        onAdd(token, normalizedAmount)
+                        onAdd(token, normalizedAmount, displayLiquidationPrice)
                     },
                 )
                 Row(
@@ -714,6 +742,7 @@ private fun PerpsAddInfoRow(
     title: String,
     value: String,
     valueColor: Color = MixinAppTheme.colors.textAssist,
+    isLoading: Boolean = false,
     onTipClick: (() -> Unit)? = null,
 ) {
     Row(
@@ -746,12 +775,20 @@ private fun PerpsAddInfoRow(
                 )
             }
         }
-        Text(
-            text = value,
-            fontSize = 14.sp,
-            color = valueColor,
-            textAlign = TextAlign.End,
-        )
+        if (isLoading) {
+            CircularProgressIndicator(
+                modifier = Modifier.size(16.dp),
+                strokeWidth = 2.dp,
+                color = MixinAppTheme.colors.textAssist,
+            )
+        } else {
+            Text(
+                text = value,
+                fontSize = 14.sp,
+                color = valueColor,
+                textAlign = TextAlign.End,
+            )
+        }
     }
 }
 
@@ -833,12 +870,8 @@ private fun calculateEstimatedLiquidationPrice(
     position: PerpsPositionItem,
     amount: String,
     currentPrice: String,
-    priceScale: Int,
-): String {
-    val existingLiquidationPrice = position.liquidationPrice
-        ?.takeIf { it.isNotBlank() }
-        ?.let { formatPerpsPrice(it, priceScale) }
-        ?: "--"
+): String? {
+    val existingLiquidationPrice = position.liquidationPrice?.takeIf { it.isNotBlank() }
     val addMargin = amount.toBigDecimalOrNull()?.takeIf { it > BigDecimal.ZERO } ?: return existingLiquidationPrice
     val currentQuantity = position.quantity.toBigDecimalOrNull()?.abs() ?: BigDecimal.ZERO
     val addQuantity = calculateAddQuantity(amount, position.leverage, currentPrice)
@@ -858,5 +891,5 @@ private fun calculateEstimatedLiquidationPrice(
     } else {
         averageEntry.multiply(BigDecimal.ONE.subtract(liquidationRatio))
     }
-    return formatPerpsPrice(estimatedPrice, priceScale)
+    return estimatedPrice.stripTrailingZeros().toPlainString()
 }

--- a/app/src/main/java/one/mixin/android/ui/home/web3/trade/perps/PerpsConfirmBottomSheetDialogFragment.kt
+++ b/app/src/main/java/one/mixin/android/ui/home/web3/trade/perps/PerpsConfirmBottomSheetDialogFragment.kt
@@ -104,6 +104,8 @@ class PerpsConfirmBottomSheetDialogFragment : MixinComposeBottomSheetDialogFragm
         private const val ARGS_TOKEN_SYMBOL = "args_token_symbol"
         private const val ARGS_TAKE_PROFIT_PRICE = "args_take_profit_price"
         private const val ARGS_STOP_LOSS_PRICE = "args_stop_loss_price"
+        private const val ARGS_LIQUIDATION_PRICE = "args_liquidation_price"
+        private const val ARGS_PRICE_SCALE = "args_price_scale"
         private const val ARGS_PAY_URL = "args_pay_url"
         private const val ARGS_IS_ADD_POSITION = "args_is_add_position"
 
@@ -117,6 +119,8 @@ class PerpsConfirmBottomSheetDialogFragment : MixinComposeBottomSheetDialogFragm
             tokenSymbol: String,
             takeProfitPrice: String? = null,
             stopLossPrice: String? = null,
+            liquidationPrice: String? = null,
+            priceScale: Int = 2,
             payUrl: String?,
             isAddPosition: Boolean = false,
         ): PerpsConfirmBottomSheetDialogFragment {
@@ -130,6 +134,8 @@ class PerpsConfirmBottomSheetDialogFragment : MixinComposeBottomSheetDialogFragm
                 putString(ARGS_TOKEN_SYMBOL, tokenSymbol)
                 putString(ARGS_TAKE_PROFIT_PRICE, takeProfitPrice)
                 putString(ARGS_STOP_LOSS_PRICE, stopLossPrice)
+                putString(ARGS_LIQUIDATION_PRICE, liquidationPrice)
+                putInt(ARGS_PRICE_SCALE, priceScale)
                 putString(ARGS_PAY_URL, payUrl)
                 putBoolean(ARGS_IS_ADD_POSITION, isAddPosition)
             }
@@ -179,6 +185,8 @@ class PerpsConfirmBottomSheetDialogFragment : MixinComposeBottomSheetDialogFragm
     private val tokenSymbol by lazy { requireNotNull(requireArguments().getString(ARGS_TOKEN_SYMBOL)) }
     private val takeProfitPrice by lazy { requireArguments().getString(ARGS_TAKE_PROFIT_PRICE).orEmpty() }
     private val stopLossPrice by lazy { requireArguments().getString(ARGS_STOP_LOSS_PRICE).orEmpty() }
+    private val rawLiquidationPrice by lazy { requireArguments().getString(ARGS_LIQUIDATION_PRICE) }
+    private val priceScale by lazy { requireArguments().getInt(ARGS_PRICE_SCALE, 2) }
     private val isAddPosition by lazy { requireArguments().getBoolean(ARGS_IS_ADD_POSITION) }
 
     private val payUrl by lazy { requireArguments().getString(ARGS_PAY_URL) }
@@ -190,28 +198,7 @@ class PerpsConfirmBottomSheetDialogFragment : MixinComposeBottomSheetDialogFragm
     private val stopLossFiatPrice by lazy { formatOptionalPerpsPrice(stopLossPrice) }
 
     private val liquidationPrice by lazy {
-        try {
-            if (leverage <= 0) {
-                "${PERPS_USD_SYMBOL}0"
-            } else {
-                val price = entryPrice.toBigDecimalOrNull() ?: BigDecimal.ZERO
-                if (price == BigDecimal.ZERO) {
-                    "${PERPS_USD_SYMBOL}0"
-                } else {
-                    val liquidationPercent = BigDecimal(100.0 / leverage)
-                    val liquidationRatio = liquidationPercent.divide(BigDecimal(100), 8, RoundingMode.HALF_UP)
-                    val liquidation = if (isLong) {
-                        price * (BigDecimal.ONE - liquidationRatio)
-                    } else {
-                        price * (BigDecimal.ONE + liquidationRatio)
-                    }
-                    "$PERPS_USD_SYMBOL${liquidation.priceFormat()}"
-                }
-            }
-        } catch (e: Exception) {
-            Timber.e(e, "Failed to calculate liquidation price")
-            "${PERPS_USD_SYMBOL}0"
-        }
+        rawLiquidationPrice?.let { formatPerpsPrice(it, priceScale) } ?: "--"
     }
 
     private var step by mutableStateOf(Step.Pending)

--- a/app/src/main/java/one/mixin/android/ui/home/web3/trade/perps/PerpsMarketDetailPage.kt
+++ b/app/src/main/java/one/mixin/android/ui/home/web3/trade/perps/PerpsMarketDetailPage.kt
@@ -477,7 +477,7 @@ fun PerpsMarketDetailPage(
                                             .setOnDestroy {
                                                 isAddingProcessing = false
                                             }
-                                            .setOnAdd { token, amount ->
+                                            .setOnAdd { token, amount, liquidationPrice ->
                                                 isAddingProcessing = false
                                                 val referencePrice = market?.last
                                                     ?: positionForAdd.markPrice
@@ -506,6 +506,8 @@ fun PerpsMarketDetailPage(
                                                             tokenSymbol = token.symbol,
                                                             takeProfitPrice = null,
                                                             stopLossPrice = null,
+                                                            liquidationPrice = liquidationPrice,
+                                                            priceScale = market?.priceScale ?: positionForAdd.priceScale,
                                                             payUrl = response.paymentUrl,
                                                             isAddPosition = true,
                                                         ).show(activity.supportFragmentManager, PerpsConfirmBottomSheetDialogFragment.TAG)


### PR DESCRIPTION
- Add loading indicator and disable button during fetch
- 200ms debounce on input changes
- Cancel previous request on new input
- Retry with 1s delay on failure until success
- Open position: keep local calculation as initial value
- Add margin: no init fetch, price passed from previous page