### PR TITLE
Require explicit browser URL schemes

### DIFF
--- a/app/src/main/java/one/mixin/android/extension/ContextExtension.kt
+++ b/app/src/main/java/one/mixin/android/extension/ContextExtension.kt
@@ -908,15 +908,8 @@ fun Context.openInBrowser(
     url: String,
     extraHeaders: Bundle? = null,
 ): Boolean {
-    val browserUrl = url.trim()
-    if (browserUrl.isBlank()) return false
-    var uri = browserUrl.toUri()
-    if (uri.scheme.isNullOrBlank()) {
-        uri = Uri.parse("http://$browserUrl")
-    }
-    if (!uri.scheme.equals("http", true) && !uri.scheme.equals("https", true)) {
-        return false
-    }
+    val browserUrl = url.toOpenInBrowserUrlOrNull() ?: return false
+    val uri = browserUrl.toUri()
 
     try {
         val customTabsIntent =

--- a/app/src/main/java/one/mixin/android/extension/StringExtension.kt
+++ b/app/src/main/java/one/mixin/android/extension/StringExtension.kt
@@ -264,6 +264,18 @@ inline fun String.isWebUrl(): Boolean {
     return startsWith("http://", true) || startsWith("https://", true)
 }
 
+fun String.toOpenInBrowserUrlOrNull(): String? {
+    val url = trim()
+    if (url.isBlank() || url.equals("undefined", true) || url.equals("null", true)) {
+        return null
+    }
+    val uri = Uri.parse(url)
+    return url.takeIf {
+        (uri.scheme.equals("http", true) || uri.scheme.equals("https", true)) &&
+            !uri.host.isNullOrBlank()
+    }
+}
+
 inline fun String.isAppUrl(): Boolean {
     val pattern = Regex("^.+:/.+$|^.+://.+$")
     return pattern.matches(this)

--- a/app/src/main/java/one/mixin/android/ui/web/WebFragment.kt
+++ b/app/src/main/java/one/mixin/android/ui/web/WebFragment.kt
@@ -125,6 +125,7 @@ import one.mixin.android.extension.openPermissionSetting
 import one.mixin.android.extension.openUrl
 import one.mixin.android.extension.putString
 import one.mixin.android.extension.showPipPermissionNotification
+import one.mixin.android.extension.toOpenInBrowserUrlOrNull
 import one.mixin.android.extension.toUri
 import one.mixin.android.extension.toast
 import one.mixin.android.extension.viewDestroyed
@@ -1059,20 +1060,6 @@ class WebFragment : BaseFragment() {
             )
         }
         return true
-    }
-
-    private fun String.toOpenInBrowserUrlOrNull(): String? {
-        val url = trim()
-        if (url.isBlank() || url.equals("undefined", true) || url.equals("null", true)) {
-            return null
-        }
-        var uri = url.toUri()
-        if (uri.scheme.isNullOrBlank()) {
-            uri = Uri.parse("http://$url")
-        }
-        return url.takeIf {
-            uri.scheme.equals("http", true) || uri.scheme.equals("https", true)
-        }
     }
 
     private fun closeSelf() {

--- a/app/src/test/java/one/mixin/android/extension/StringExtensionTest.kt
+++ b/app/src/test/java/one/mixin/android/extension/StringExtensionTest.kt
@@ -191,4 +191,18 @@ class StringExtensionTest {
     fun isMixinUrlRecognizesMixinBuy() {
         assertTrue("mixin://mixin.one/buy".isMixinUrl())
     }
+
+    @Test
+    fun openInBrowserUrlRequiresExplicitWebScheme() {
+        assertEquals("https://mixin.one/pay", " https://mixin.one/pay ".toOpenInBrowserUrlOrNull())
+        assertEquals("http://mixin.one/pay", "http://mixin.one/pay".toOpenInBrowserUrlOrNull())
+        assertEquals(null, "mixin.one/pay".toOpenInBrowserUrlOrNull())
+        assertEquals(null, "http:foo".toOpenInBrowserUrlOrNull())
+        assertEquals(null, "https:mixin.one".toOpenInBrowserUrlOrNull())
+        assertEquals(null, "https://".toOpenInBrowserUrlOrNull())
+        assertEquals(null, "".toOpenInBrowserUrlOrNull())
+        assertEquals(null, "undefined".toOpenInBrowserUrlOrNull())
+        assertEquals(null, "javascript:alert(1)".toOpenInBrowserUrlOrNull())
+        assertEquals(null, "mixin://codes/test".toOpenInBrowserUrlOrNull())
+    }
 }


### PR DESCRIPTION
## Summary
- Require `openInBrowser` bridge URLs to include an explicit `http://` or `https://` scheme.
- Share the open-in-browser URL validator between the web bridge and `Context.openInBrowser`.
- Add unit coverage for accepting explicit HTTP/HTTPS URLs and rejecting bare or non-web schemes.

## Validation
- Ran whitespace diff checks.
- Targeted Android unit test could not run locally because the available Java runtime is older than Gradle's minimum requirement; CI is configured with JDK 17.

Related iOS PR: https://github.com/MixinNetwork/ios-app/pull/2073