### PR TITLE
fix(pay): normalize ethereum:// to ethereum: before parsing and allow…

### DIFF
--- a/app/src/main/java/one/mixin/android/pay/Ethereum.kt
+++ b/app/src/main/java/one/mixin/android/pay/Ethereum.kt
@@ -20,7 +20,12 @@ internal suspend fun parseEthereum(
     getAssetPrecisionById: suspend (String) -> AssetPrecision?,
     balanceCheck: suspend (String, BigDecimal, String?, BigDecimal?) -> Unit,
 ): ExternalTransfer? {
-    val erc681 = EthereumURI(url).toERC681()
+    val normalized = if (url.startsWith("ethereum://", ignoreCase = true)) {
+        "ethereum:" + url.substring("ethereum://".length)
+    } else {
+        url
+    }
+    val erc681 = EthereumURI(normalized).toERC681()
     if (!erc681.valid) return null
 
     val chainId = erc681.chainId?.toInt() ?: 1


### PR DESCRIPTION
… nullable destination

- Strip double-slash prefix in parseEthereum() so ethereum://address@chainId parses correctly instead of yielding an empty address
- Make validateExternalAddress destination parameter nullable so empty destination is omitted from the request rather than sent as blank