### PR TITLE
fix(perps): fall back to current liquidation price on add when input …

### DIFF
--- a/app/src/main/java/one/mixin/android/ui/home/web3/trade/perps/PerpsAddBottomSheetDialogFragment.kt
+++ b/app/src/main/java/one/mixin/android/ui/home/web3/trade/perps/PerpsAddBottomSheetDialogFragment.kt
@@ -280,7 +280,10 @@ private fun PerpsAddContent(
 
     LaunchedEffect(amount) {
         val addMargin = amount.toBigDecimalOrNull()
-        if (addMargin == null || addMargin <= BigDecimal.ZERO) {
+        if (addMargin == null || addMargin <= BigDecimal.ZERO || belowMinimumMargin || aboveMaximumMargin) {
+            liquidationJob?.cancel()
+            remoteLiquidationPrice = null
+            isLiquidationLoading = false
             return@LaunchedEffect
         }
         liquidationJob?.cancel()
@@ -320,6 +323,7 @@ private fun PerpsAddContent(
 
     val currentPriceText = formatPerpsPrice(currentPrice, priceScale)
     val displayLiquidationPrice = remoteLiquidationPrice
+        ?: position.liquidationPrice?.takeIf { it.isNotBlank() }
     val entryPriceText = position.entryPrice
         .takeIf { it.isNotBlank() }
         ?.let { formatPerpsPrice(it, priceScale) }


### PR DESCRIPTION
…invalid

On the add-position sheet the position already has a liquidation price, so show the existing position.liquidationPrice instead of "--" whenever the input amount is invalid: empty, non-positive, or out of the allowed margin range (below min / above max). The stale remote estimate is cleared in those cases so the fallback takes effect. (Open-position still shows "-" since there is no position yet.)