### PR TITLE
fix(wallet): support buy webview permissions

### DIFF
--- a/app/src/main/java/one/mixin/android/ui/common/WebBottomSheetDialogFragment.kt
+++ b/app/src/main/java/one/mixin/android/ui/common/WebBottomSheetDialogFragment.kt
@@ -1,36 +1,64 @@
 package one.mixin.android.ui.common
 
+import android.Manifest
+import android.app.Activity
 import android.annotation.SuppressLint
 import android.app.Dialog
 import android.content.ActivityNotFoundException
 import android.content.Intent
+import android.content.Intent.ACTION_VIEW
+import android.content.Intent.CATEGORY_BROWSABLE
+import android.content.Intent.FLAG_ACTIVITY_REQUIRE_NON_BROWSER
 import android.net.Uri
 import android.graphics.Rect
+import android.os.Build
+import android.os.Bundle
+import android.provider.MediaStore
 import android.view.ViewTreeObserver
 import android.webkit.CookieManager
+import android.webkit.GeolocationPermissions
+import android.webkit.PermissionRequest
+import android.webkit.ValueCallback
 import android.webkit.WebChromeClient
 import android.webkit.WebResourceRequest
 import android.webkit.WebSettings
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.activity.addCallback
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.fragment.app.FragmentManager
 import androidx.lifecycle.lifecycleScope
+import androidx.webkit.WebSettingsCompat
+import androidx.webkit.WebViewFeature
+import com.uber.autodispose.autoDispose
 import one.mixin.android.BuildConfig
 import one.mixin.android.Constants
 import one.mixin.android.R
 import one.mixin.android.databinding.FragmentWebBottomSheetBinding
+import one.mixin.android.extension.REQUEST_CAMERA
+import one.mixin.android.extension.createImageTemp
+import one.mixin.android.extension.getOtherPath
 import one.mixin.android.extension.isExternalTransferUrl
 import one.mixin.android.extension.isLightningUrl
 import one.mixin.android.extension.isMixinUrl
+import one.mixin.android.extension.openCamera
 import one.mixin.android.extension.openAsUrl
+import one.mixin.android.extension.openPermissionSetting
+import one.mixin.android.extension.toUri
 import one.mixin.android.extension.toast
 import one.mixin.android.extension.withArgs
+import one.mixin.android.ui.conversation.web.PermissionBottomSheetDialogFragment
+import one.mixin.android.ui.conversation.web.PermissionBottomSheetDialogFragment.Companion.PERMISSION_AUDIO
+import one.mixin.android.ui.conversation.web.PermissionBottomSheetDialogFragment.Companion.PERMISSION_VIDEO
 import one.mixin.android.ui.url.UrlInterpreterActivity
+import one.mixin.android.util.rxpermission.RxPermissions
 import one.mixin.android.util.viewBinding
 import one.mixin.android.web3.convertWcLink
 import one.mixin.android.widget.BottomSheet
 import timber.log.Timber
+import java.net.URI
+import java.util.Locale
 
 class WebBottomSheetDialogFragment : MixinBottomSheetDialogFragment() {
     companion object {
@@ -75,6 +103,11 @@ class WebBottomSheetDialogFragment : MixinBottomSheetDialogFragment() {
     private var bottomSheet: BottomSheet? = null
     private var lastVisibleHeight = 0
     private var lastHandledUrl: Pair<String, Long>? = null
+    private var lastGrantedUri: String? = null
+    private var uploadMessage: ValueCallback<Array<Uri>>? = null
+    private var imageUri: Uri? = null
+    private lateinit var fileChooser: ActivityResultLauncher<Intent>
+    private lateinit var videoCapture: ActivityResultLauncher<Intent>
     private val keyboardLayoutListener =
         ViewTreeObserver.OnGlobalLayoutListener {
             val visibleHeight = getDialogVisibleHeight()
@@ -83,6 +116,25 @@ class WebBottomSheetDialogFragment : MixinBottomSheetDialogFragment() {
             lastVisibleHeight = visibleHeight
             bottomSheet?.setCustomViewHeightSync(visibleHeight)
         }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        fileChooser = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
+            uploadMessage?.onReceiveValue(
+                WebChromeClient.FileChooserParams.parseResult(result.resultCode, result.data),
+            )
+            uploadMessage = null
+        }
+        videoCapture = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
+            val uri = result.data?.data
+            if (result.resultCode == Activity.RESULT_OK && uri != null) {
+                uploadMessage?.onReceiveValue(arrayOf(uri))
+            } else {
+                uploadMessage?.onReceiveValue(null)
+            }
+            uploadMessage = null
+        }
+    }
 
     @SuppressLint("RestrictedApi", "SetJavaScriptEnabled")
     override fun setupDialog(
@@ -102,9 +154,42 @@ class WebBottomSheetDialogFragment : MixinBottomSheetDialogFragment() {
             settings.mixedContentMode = WebSettings.MIXED_CONTENT_COMPATIBILITY_MODE
             settings.mediaPlaybackRequiresUserGesture = false
             settings.javaScriptCanOpenWindowsAutomatically = true
-            settings.userAgentString = settings.userAgentString + " Mixin/" + BuildConfig.VERSION_NAME
-            webChromeClient = object : WebChromeClient() {}
+            settings.setGeolocationEnabled(true)
+            settings.userAgentString = settings.userAgentString + " Mixin/" + BuildConfig.VERSION_NAME + " GOOGLE_PAY_SUPPORTED"
+            if (WebViewFeature.isFeatureSupported(WebViewFeature.PAYMENT_REQUEST)) {
+                WebSettingsCompat.setPaymentRequestEnabled(settings, true)
+            }
+            webChromeClient =
+                object : WebChromeClient() {
+                    override fun onPermissionRequest(request: PermissionRequest?) {
+                        handlePermissionRequest(request)
+                    }
+
+                    override fun onShowFileChooser(
+                        webView: WebView?,
+                        filePathCallback: ValueCallback<Array<Uri>>?,
+                        fileChooserParams: FileChooserParams?,
+                    ): Boolean {
+                        return handleFileChooser(filePathCallback, fileChooserParams)
+                    }
+
+                    override fun onGeolocationPermissionsShowPrompt(
+                        origin: String?,
+                        callback: GeolocationPermissions.Callback?,
+                    ) {
+                        handleGeolocationPermission(origin, callback)
+                    }
+                }
             webViewClient = BottomSheetWebViewClient()
+            setDownloadListener { url, _, _, _, _ ->
+                runCatching {
+                    startActivity(
+                        Intent(ACTION_VIEW).apply {
+                            data = url.toUri()
+                        },
+                    )
+                }
+            }
         }
         CookieManager.getInstance().apply {
             setAcceptCookie(true)
@@ -152,7 +237,192 @@ class WebBottomSheetDialogFragment : MixinBottomSheetDialogFragment() {
             removeAllViews()
             destroy()
         }
+        uploadMessage?.onReceiveValue(null)
+        uploadMessage = null
         super.onDestroyView()
+    }
+
+    private fun handlePermissionRequest(request: PermissionRequest?) {
+        request ?: return
+        val permissions = mutableListOf<String>()
+        val promptTypes = mutableListOf<Int>()
+        for (resource in request.resources) {
+            when (resource) {
+                PermissionRequest.RESOURCE_AUDIO_CAPTURE -> {
+                    permissions.add(Manifest.permission.RECORD_AUDIO)
+                    promptTypes.add(PERMISSION_AUDIO)
+                }
+                PermissionRequest.RESOURCE_VIDEO_CAPTURE -> {
+                    permissions.add(Manifest.permission.CAMERA)
+                    promptTypes.add(PERMISSION_VIDEO)
+                }
+                else -> {
+                    lastGrantedUri = null
+                    request.deny()
+                    return
+                }
+            }
+        }
+        if (lastGrantedUri == request.origin.toString()) {
+            request.grant(request.resources)
+            return
+        }
+
+        PermissionBottomSheetDialogFragment.request(
+            title,
+            null,
+            null,
+            *promptTypes.toIntArray(),
+        )
+            .setCancelAction {
+                lastGrantedUri = null
+                request.deny()
+            }.setGrantedAction {
+                RxPermissions(requireActivity())
+                    .request(*permissions.toTypedArray())
+                    .autoDispose(stopScope)
+                    .subscribe(
+                        { granted ->
+                            if (granted) {
+                                lastGrantedUri = request.origin.toString()
+                                request.grant(request.resources)
+                            } else {
+                                lastGrantedUri = null
+                                context?.openPermissionSetting()
+                            }
+                        },
+                        {
+                            lastGrantedUri = null
+                            request.deny()
+                        },
+                    )
+            }.show(parentFragmentManager, PermissionBottomSheetDialogFragment.TAG)
+    }
+
+    private fun handleFileChooser(
+        filePathCallback: ValueCallback<Array<Uri>>?,
+        fileChooserParams: WebChromeClient.FileChooserParams?,
+    ): Boolean {
+        uploadMessage?.onReceiveValue(null)
+        uploadMessage = filePathCallback
+        val intent = fileChooserParams?.createIntent()
+        if (fileChooserParams?.isCaptureEnabled == true) {
+            when (intent?.type) {
+                "video/*" -> {
+                    PermissionBottomSheetDialogFragment.requestVideo(title)
+                        .setCancelAction { cancelFileChooser() }
+                        .setGrantedAction {
+                            RxPermissions(requireActivity())
+                                .request(Manifest.permission.CAMERA)
+                                .autoDispose(stopScope)
+                                .subscribe(
+                                    { granted ->
+                                        if (granted) {
+                                            videoCapture.launch(Intent(MediaStore.ACTION_VIDEO_CAPTURE))
+                                        } else {
+                                            cancelFileChooser()
+                                            context?.openPermissionSetting()
+                                        }
+                                    },
+                                    {
+                                        cancelFileChooser()
+                                    },
+                                )
+                        }.show(parentFragmentManager, PermissionBottomSheetDialogFragment.TAG)
+                    return true
+                }
+                "image/*" -> {
+                    PermissionBottomSheetDialogFragment.requestCamera(title)
+                        .setCancelAction { cancelFileChooser() }
+                        .setGrantedAction {
+                            RxPermissions(requireActivity())
+                                .request(Manifest.permission.CAMERA)
+                                .autoDispose(stopScope)
+                                .subscribe(
+                                    { granted ->
+                                        if (granted) {
+                                            openCamera(getImageUri())
+                                        } else {
+                                            cancelFileChooser()
+                                            context?.openPermissionSetting()
+                                        }
+                                    },
+                                    {
+                                        cancelFileChooser()
+                                    },
+                                )
+                        }.show(parentFragmentManager, PermissionBottomSheetDialogFragment.TAG)
+                    return true
+                }
+            }
+        }
+
+        if (intent == null) {
+            cancelFileChooser()
+            return false
+        }
+        runCatching {
+            fileChooser.launch(intent)
+        }.onFailure {
+            cancelFileChooser()
+        }
+        return true
+    }
+
+    private fun cancelFileChooser() {
+        uploadMessage?.onReceiveValue(null)
+        uploadMessage = null
+    }
+
+    private fun getImageUri(): Uri {
+        if (imageUri == null) {
+            imageUri = Uri.fromFile(requireContext().getOtherPath().createImageTemp())
+        }
+        return requireNotNull(imageUri)
+    }
+
+    @Deprecated("Deprecated in Java")
+    override fun onActivityResult(
+        requestCode: Int,
+        resultCode: Int,
+        data: Intent?,
+    ) {
+        if (resultCode == Activity.RESULT_OK && requestCode == REQUEST_CAMERA) {
+            imageUri?.let {
+                uploadMessage?.onReceiveValue(arrayOf(it))
+                imageUri = null
+            }
+            uploadMessage = null
+        } else {
+            cancelFileChooser()
+        }
+    }
+
+    private fun handleGeolocationPermission(
+        origin: String?,
+        callback: GeolocationPermissions.Callback?,
+    ) {
+        PermissionBottomSheetDialogFragment.requestLocation(title)
+            .setCancelAction {
+                callback?.invoke(origin, false, false)
+            }.setGrantedAction {
+                RxPermissions(requireActivity())
+                    .request(Manifest.permission.ACCESS_COARSE_LOCATION, Manifest.permission.ACCESS_FINE_LOCATION)
+                    .autoDispose(stopScope)
+                    .subscribe(
+                        { granted ->
+                            if (granted) {
+                                callback?.invoke(origin, true, false)
+                            } else {
+                                callback?.invoke(origin, false, false)
+                                requireContext().openPermissionSetting()
+                            }
+                        },
+                        {
+                            callback?.invoke(origin, false, false)
+                        },
+                    )
+            }.show(parentFragmentManager, PermissionBottomSheetDialogFragment.TAG)
     }
 
     private inner class BottomSheetWebViewClient : WebViewClient() {
@@ -205,18 +475,7 @@ class WebBottomSheetDialogFragment : MixinBottomSheetDialogFragment() {
             return when (uri.scheme?.lowercase()) {
                 "http", "https" -> false
                 else -> {
-                    val context = view?.context ?: context ?: return false
-                    runCatching {
-                        context.startActivity(Intent(Intent.ACTION_VIEW, uri))
-                    }.onFailure {
-                        if (it !is ActivityNotFoundException) {
-                            Timber.w(it)
-                        }
-                    }.isSuccess.also { handled ->
-                        if (handled && request.isForMainFrame) {
-                            dismiss()
-                        }
-                    }
+                    openExternalUrl(view, request, url)
                 }
             }
         }
@@ -248,6 +507,56 @@ class WebBottomSheetDialogFragment : MixinBottomSheetDialogFragment() {
             if (request?.isForMainFrame == true) {
                 toast(R.string.Try_Again)
             }
+        }
+    }
+
+    private fun openExternalUrl(
+        view: WebView?,
+        request: WebResourceRequest,
+        url: String,
+    ): Boolean {
+        return try {
+            val context = view?.context ?: context ?: return false
+            val intent =
+                Intent.parseUri(url, Intent.URI_INTENT_SCHEME).apply {
+                    action = ACTION_VIEW
+                    addCategory(CATEGORY_BROWSABLE)
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                        flags = FLAG_ACTIVITY_REQUIRE_NON_BROWSER
+                    }
+                    if (context !is Activity) {
+                        addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                    }
+                }
+            try {
+                context.startActivity(intent)
+                if (request.isForMainFrame) {
+                    dismiss()
+                }
+                true
+            } catch (e: ActivityNotFoundException) {
+                val fallbackUrl = intent.extras?.getString("browser_fallback_url")
+                if (fallbackUrl != null && isFallbackUrlValid(fallbackUrl)) {
+                    view?.loadUrl(fallbackUrl)
+                    true
+                } else {
+                    false
+                }
+            }
+        } catch (e: Exception) {
+            if (e !is ActivityNotFoundException) {
+                Timber.w(e)
+            }
+            false
+        }
+    }
+
+    private fun isFallbackUrlValid(fallbackUrl: String): Boolean {
+        return try {
+            val scheme = URI(fallbackUrl).scheme?.lowercase(Locale.US)
+            scheme == "http" || scheme == "https"
+        } catch (e: Exception) {
+            false
         }
     }
 }

--- a/app/src/main/java/one/mixin/android/ui/common/WebBottomSheetDialogFragment.kt
+++ b/app/src/main/java/one/mixin/android/ui/common/WebBottomSheetDialogFragment.kt
@@ -288,6 +288,7 @@ class WebBottomSheetDialogFragment : MixinBottomSheetDialogFragment() {
                                 request.grant(request.resources)
                             } else {
                                 lastGrantedUri = null
+                                request.deny()
                                 context?.openPermissionSetting()
                             }
                         },
@@ -387,6 +388,7 @@ class WebBottomSheetDialogFragment : MixinBottomSheetDialogFragment() {
         resultCode: Int,
         data: Intent?,
     ) {
+        super.onActivityResult(requestCode, resultCode, data)
         if (resultCode == Activity.RESULT_OK && requestCode == REQUEST_CAMERA) {
             imageUri?.let {
                 uploadMessage?.onReceiveValue(arrayOf(it))
@@ -522,7 +524,7 @@ class WebBottomSheetDialogFragment : MixinBottomSheetDialogFragment() {
                     action = ACTION_VIEW
                     addCategory(CATEGORY_BROWSABLE)
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-                        flags = FLAG_ACTIVITY_REQUIRE_NON_BROWSER
+                        addFlags(FLAG_ACTIVITY_REQUIRE_NON_BROWSER)
                     }
                     if (context !is Activity) {
                         addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)


### PR DESCRIPTION
## Summary
- Add WebChromeClient handling for buy bottom sheet WebView audio/video permission requests.
- Support file chooser, capture upload, geolocation prompts, downloads, Payment Request, and external intent fallback.
- Keep real buy ramp URL flow unchanged.

## Test Plan
- ./gradlew :app:compileGooglePlayDebugKotlin --no-build-cache