### PR TITLE
Hide missing localized market descriptions

### DIFF
--- a/app/src/main/java/one/mixin/android/ui/wallet/MarketDescription.kt
+++ b/app/src/main/java/one/mixin/android/ui/wallet/MarketDescription.kt
@@ -1,0 +1,6 @@
+package one.mixin.android.ui.wallet
+
+fun selectLocalizedMarketDescription(
+    descriptions: Map<String, String>,
+    language: String,
+): String? = descriptions[language]?.takeIf { it.isNotBlank() }

--- a/app/src/main/java/one/mixin/android/ui/wallet/MarketDetailsFragment.kt
+++ b/app/src/main/java/one/mixin/android/ui/wallet/MarketDetailsFragment.kt
@@ -352,9 +352,7 @@ class MarketDetailsFragment : BaseFragment(R.layout.fragment_details_market) {
 
                     val desc = info.descriptions?.let { map ->
                         val lang = Locale.getDefault().language
-                        (map[lang]?.takeIf { it.isNotBlank() }
-                            ?: map["en"]?.takeIf { it.isNotBlank() }
-                            ?: map.values.firstOrNull { it.isNotBlank() })
+                        selectLocalizedMarketDescription(map, lang)
                     }?.let { HtmlCompat.fromHtml(it, HtmlCompat.FROM_HTML_MODE_LEGACY).toString().trim() }
                     aboutContainer.isVisible = !desc.isNullOrBlank()
                     aboutContent.text = desc.orEmpty()


### PR DESCRIPTION
## Summary
- Remove English and arbitrary non-empty fallback for market descriptions.
- Hide the market about section when the current locale has no non-blank description.

## Verification
- ./gradlew :app:compileGooglePlayDebugKotlin