### PR TITLE
fix(wallet): hide missing market description

### DIFF
--- a/app/src/main/java/one/mixin/android/ui/wallet/MarketDescription.kt
+++ b/app/src/main/java/one/mixin/android/ui/wallet/MarketDescription.kt
@@ -1,0 +1,6 @@
+package one.mixin.android.ui.wallet
+
+fun selectLocalizedMarketDescription(
+    descriptions: Map<String, String>,
+    language: String,
+): String? = descriptions[language]?.takeIf { it.isNotBlank() }

--- a/app/src/main/java/one/mixin/android/ui/wallet/MarketDetailsFragment.kt
+++ b/app/src/main/java/one/mixin/android/ui/wallet/MarketDetailsFragment.kt
@@ -352,9 +352,7 @@ class MarketDetailsFragment : BaseFragment(R.layout.fragment_details_market) {
 
                     val desc = info.descriptions?.let { map ->
                         val lang = Locale.getDefault().language
-                        (map[lang]?.takeIf { it.isNotBlank() }
-                            ?: map["en"]?.takeIf { it.isNotBlank() }
-                            ?: map.values.firstOrNull { it.isNotBlank() })
+                        selectLocalizedMarketDescription(map, lang)
                     }?.let { HtmlCompat.fromHtml(it, HtmlCompat.FROM_HTML_MODE_LEGACY).toString().trim() }
                     aboutContainer.isVisible = !desc.isNullOrBlank()
                     aboutContent.text = desc.orEmpty()


### PR DESCRIPTION
## Summary
- Hide the market description when there is no description content.
- Keep market detail description handling centralized in the wallet UI.

## Test Plan
- ./gradlew :app:compileGooglePlayDebugKotlin