### PR TITLE
fix(trade): preserve swap output initialization

### DIFF
--- a/app/src/main/java/one/mixin/android/ui/home/web3/trade/SwapTokenSelection.kt
+++ b/app/src/main/java/one/mixin/android/ui/home/web3/trade/SwapTokenSelection.kt
@@ -1,0 +1,32 @@
+package one.mixin.android.ui.home.web3.trade
+
+import one.mixin.android.Constants
+import one.mixin.android.api.response.web3.SwapToken
+
+internal data class SwapTokenPair(
+    val from: SwapToken?,
+    val to: SwapToken?,
+)
+
+internal fun resolveDuplicateSwapTokenPair(
+    tokens: List<SwapToken>,
+    fromToken: SwapToken?,
+    toToken: SwapToken?,
+    keepToToken: Boolean,
+): SwapTokenPair {
+    if (fromToken?.getUnique() != toToken?.getUnique()) {
+        return SwapTokenPair(fromToken, toToken)
+    }
+
+    val fallback = tokens.firstOrNull { t ->
+        t.getUnique() != fromToken?.getUnique() && t.getUnique() in Constants.usdIds
+    } ?: tokens.firstOrNull { t ->
+        t.getUnique() != fromToken?.getUnique()
+    }
+
+    return if (keepToToken) {
+        SwapTokenPair(fallback, toToken)
+    } else {
+        SwapTokenPair(fromToken, fallback)
+    }
+}

--- a/app/src/main/java/one/mixin/android/ui/home/web3/trade/TradeFragment.kt
+++ b/app/src/main/java/one/mixin/android/ui/home/web3/trade/TradeFragment.kt
@@ -1250,7 +1250,7 @@ class TradeFragment : BaseFragment() {
         val lastFrom = lastSelectedPair?.getOrNull(0)
         val lastTo = lastSelectedPair?.getOrNull(1)
 
-        val tempFromToken = if (input != null) {
+        var tempFromToken = if (input != null) {
             if (inMixin()) swapViewModel.findToken(input)?.toSwapToken() else swapViewModel.web3TokenItemById(walletId!!, input)?.toSwapToken()
         } else if (lastFrom != null) {
             if (inMixin()) swapViewModel.findToken(lastFrom.assetId)?.toSwapToken() else swapViewModel.web3TokenItemById(walletId!!, lastFrom.assetId)?.toSwapToken()
@@ -1271,8 +1271,14 @@ class TradeFragment : BaseFragment() {
         } else {
             tokens.firstOrNull { t -> t.getUnique() != tempFromToken?.getUnique() && t.getUnique() in Constants.usdIds }
         }
-        if (tempToToken?.getUnique() == tempFromToken?.getUnique()) {
-            tempToToken = tokens.firstOrNull { t -> t.getUnique() != tempFromToken?.getUnique() && t.getUnique() in Constants.usdIds } ?: tokens.firstOrNull { t -> t.getUnique() != tempFromToken?.getUnique() }
+        resolveDuplicateSwapTokenPair(
+            tokens = tokens,
+            fromToken = tempFromToken,
+            toToken = tempToToken,
+            keepToToken = output != null,
+        ).let { pair ->
+            tempFromToken = pair.from
+            tempToToken = pair.to
         }
 
         if (isLimit) {

--- a/app/src/test/java/one/mixin/android/ui/home/web3/trade/SwapTokenSelectionTest.kt
+++ b/app/src/test/java/one/mixin/android/ui/home/web3/trade/SwapTokenSelectionTest.kt
@@ -1,0 +1,53 @@
+package one.mixin.android.ui.home.web3.trade
+
+import one.mixin.android.Constants.AssetId.USDT_ASSET_ETH_ID
+import one.mixin.android.api.response.web3.SwapChain
+import one.mixin.android.api.response.web3.SwapToken
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class SwapTokenSelectionTest {
+    @Test
+    fun outputArgumentKeepsTargetAndMovesDuplicateFromToBaseToken() {
+        val output = token("output")
+        val base = token(USDT_ASSET_ETH_ID)
+
+        val result = resolveDuplicateSwapTokenPair(
+            tokens = listOf(output, base),
+            fromToken = output,
+            toToken = output,
+            keepToToken = true,
+        )
+
+        assertEquals(base.assetId, result.from?.assetId)
+        assertEquals(output.assetId, result.to?.assetId)
+    }
+
+    @Test
+    fun missingOutputArgumentKeepsFromAndMovesDuplicateToToken() {
+        val from = token("from")
+        val base = token(USDT_ASSET_ETH_ID)
+
+        val result = resolveDuplicateSwapTokenPair(
+            tokens = listOf(from, base),
+            fromToken = from,
+            toToken = from,
+            keepToToken = false,
+        )
+
+        assertEquals(from.assetId, result.from?.assetId)
+        assertEquals(base.assetId, result.to?.assetId)
+    }
+
+    private fun token(assetId: String) =
+        SwapToken(
+            walletId = null,
+            address = "",
+            assetId = assetId,
+            decimals = 8,
+            name = assetId,
+            symbol = assetId,
+            icon = "",
+            chain = SwapChain("", "", "", ""),
+        )
+}


### PR DESCRIPTION
## Summary
- Preserve URL-provided swap output token when the remembered from token duplicates it.
- Move the duplicate from token back to a base token instead of replacing the requested output.
- Add unit coverage for both output-protected and existing fallback behavior.

## Test Plan
- [x] ./gradlew :app:testOtherChannelDebugUnitTest --tests "one.mixin.android.ui.home.web3.trade.SwapTokenSelectionTest"
- [x] git diff --check