### PR TITLE
Prevent captcha retry loop during login

### DIFF
--- a/app/src/main/java/one/mixin/android/ui/landing/MnemonicPhraseFragment.kt
+++ b/app/src/main/java/one/mixin/android/ui/landing/MnemonicPhraseFragment.kt
@@ -294,9 +294,9 @@ class MnemonicPhraseFragment : BaseFragment(R.layout.fragment_compose) {
                 failureBlock = { r ->
                     if (r.errorCode == NEED_CAPTCHA) {
                         needCaptcha = true
-                        errorInfo = null
-                        landingViewModel.updateMnemonicPhraseState(MnemonicPhraseState.Creating)
-                        initAndLoadCaptcha(sessionKey, edKey, r.errorDescription)
+                        errorInfo = requireContext().getMixinErrorStringByCode(ErrorHandler.RECAPTCHA_IS_INVALID, r.errorDescription)
+                        landingViewModel.updateMnemonicPhraseState(MnemonicPhraseState.Failure)
+                        binding.mobileCover.isVisible = false
                     } else {
                         errorInfo = requireContext().getMixinErrorStringByCode(r.errorCode, r.errorDescription)
                         landingViewModel.updateMnemonicPhraseState(MnemonicPhraseState.Failure)

--- a/app/src/main/java/one/mixin/android/ui/landing/MobileFragment.kt
+++ b/app/src/main/java/one/mixin/android/ui/landing/MobileFragment.kt
@@ -396,7 +396,12 @@ class MobileFragment: BaseFragment(R.layout.fragment_mobile) {
                 { r: MixinResponse<VerificationResponse> ->
                     if (!r.isSuccess) {
                         if (r.errorCode == NEED_CAPTCHA) {
-                            initAndLoadCaptcha(r.errorDescription)
+                            if (captchaResponse == null) {
+                                initAndLoadCaptcha(r.errorDescription)
+                            } else {
+                                hideLoading()
+                                ErrorHandler.handleMixinError(ErrorHandler.RECAPTCHA_IS_INVALID, r.errorDescription)
+                            }
                         } else {
                             hideLoading()
                             ErrorHandler.handleMixinError(r.errorCode, r.errorDescription)

--- a/app/src/main/java/one/mixin/android/ui/landing/VerificationFragment.kt
+++ b/app/src/main/java/one/mixin/android/ui/landing/VerificationFragment.kt
@@ -428,7 +428,12 @@ class VerificationFragment : PinCodeFragment(R.layout.fragment_verification) {
                 { r: MixinResponse<VerificationResponse> ->
                     if (!r.isSuccess) {
                         if (r.errorCode == NEED_CAPTCHA) {
-                            initAndLoadCaptcha(r.errorDescription)
+                            if (captchaResponse == null) {
+                                initAndLoadCaptcha(r.errorDescription)
+                            } else {
+                                hideLoading()
+                                ErrorHandler.handleMixinError(ErrorHandler.RECAPTCHA_IS_INVALID, r.errorDescription)
+                            }
                         } else {
                             hideLoading()
                             ErrorHandler.handleMixinError(r.errorCode, r.errorDescription)

--- a/app/src/main/java/one/mixin/android/ui/setting/delete/DeleteAccountFragment.kt
+++ b/app/src/main/java/one/mixin/android/ui/setting/delete/DeleteAccountFragment.kt
@@ -217,7 +217,12 @@ class DeleteAccountFragment : BaseFragment(R.layout.fragment_delete_account) {
             failureBlock = { r ->
                 if (viewDestroyed()) return@handleMixinResponse true
                 if (r.errorCode == ErrorHandler.NEED_CAPTCHA) {
-                    initAndLoadCaptcha(r.errorDescription)
+                    if (captchaResponse == null) {
+                        initAndLoadCaptcha(r.errorDescription)
+                    } else {
+                        binding.deleteCover.isVisible = false
+                        ErrorHandler.handleMixinError(ErrorHandler.RECAPTCHA_IS_INVALID, r.errorDescription)
+                    }
                     return@handleMixinResponse true
                 }
                 binding.deleteCover.isVisible = false


### PR DESCRIPTION
## Summary
- Stop automatically reopening captcha when a captcha-token retry still returns NEED_CAPTCHA.
- Restore loading state and surface the existing invalid captcha error across login, resend, mnemonic, and delete-account verification flows.

## Test
- JAVA_HOME=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home ./gradlew :app:compileGooglePlayDebugKotlin
- Verified the latest commit has a valid SSH git signature locally.