### PR TITLE
Support pasting clipboard images in chat

### DIFF
--- a/app/src/main/java/one/mixin/android/ui/conversation/ConversationFragment.kt
+++ b/app/src/main/java/one/mixin/android/ui/conversation/ConversationFragment.kt
@@ -281,6 +281,7 @@ import one.mixin.android.widget.DraggableRecyclerView
 import one.mixin.android.widget.LinearSmoothScrollerCustom
 import one.mixin.android.widget.MixinHeadersDecoration
 import one.mixin.android.widget.buildBottomSheetView
+import one.mixin.android.widget.gallery.MimeType
 import one.mixin.android.widget.gallery.ui.GalleryActivity.Companion.IS_VIDEO
 import one.mixin.android.widget.keyboard.KeyboardLayout.OnKeyboardHiddenListener
 import one.mixin.android.widget.keyboard.KeyboardLayout.OnKeyboardShownListener
@@ -1504,9 +1505,12 @@ class ConversationFragment() :
                     flags: Int,
                     opts: Bundle?,
                 ) {
-                    lifecycleScope.launch(Dispatchers.IO) {
-                        if (inputContentInfo != null) {
-                            sendImageMessage(inputContentInfo.contentUri, false, null, true)
+                    val uri = inputContentInfo?.contentUri ?: return
+                    if (opts?.getBoolean(ContentEditText.OPTION_FROM_CLIPBOARD, false) == true) {
+                        handleClipboardImage(uri, opts.getString(ContentEditText.OPTION_CONTENT_MIME_TYPE))
+                    } else {
+                        lifecycleScope.launch(Dispatchers.IO) {
+                            sendImageMessage(uri, false, null, true)
                         }
                     }
                 }
@@ -2133,6 +2137,25 @@ class ConversationFragment() :
     private fun encryptCategory(): EncryptCategory = getEncryptedCategory(isBot, app)
 
     private var lastSendMessageId: String? = null
+
+    private fun handleClipboardImage(
+        uri: Uri,
+        mimeType: String?,
+    ) {
+        val imageMimeType = mimeType ?: getMimeType(uri, true)
+        when {
+            imageMimeType.equals(MimeType.GIF.toString(), true) ||
+                imageMimeType.equals(MimeType.WEBP.toString(), true) -> {
+                showPreview(uri, getString(R.string.Send), false) { imageUri, _, _ ->
+                    sendImageMessage(imageUri, mimeType = imageMimeType)
+                }
+            }
+            imageMimeType?.isImageSupport() == true -> {
+                getEditorResult.launch(Pair(uri, getString(R.string.Send)))
+            }
+            else -> toast(R.string.Format_not_supported)
+        }
+    }
 
     private fun sendImageMessage(
         uri: Uri,

--- a/app/src/main/java/one/mixin/android/widget/ContentEditText.kt
+++ b/app/src/main/java/one/mixin/android/widget/ContentEditText.kt
@@ -2,6 +2,7 @@ package one.mixin.android.widget
 
 import android.annotation.SuppressLint
 import android.content.ClipData
+import android.content.ClipDescription
 import android.content.ClipboardManager
 import android.content.Context
 import android.os.Build
@@ -24,6 +25,11 @@ import one.mixin.android.extension.supportsOreo
 import one.mixin.android.widget.gallery.MimeType
 
 open class ContentEditText : AppCompatEditText {
+    companion object {
+        const val OPTION_FROM_CLIPBOARD = "one.mixin.android.widget.ContentEditText.FROM_CLIPBOARD"
+        const val OPTION_CONTENT_MIME_TYPE = "one.mixin.android.widget.ContentEditText.CONTENT_MIME_TYPE"
+    }
+
     constructor(context: Context) : super(context)
 
     constructor(context: Context, attrs: AttributeSet) : super(context, attrs)
@@ -72,6 +78,9 @@ open class ContentEditText : AppCompatEditText {
     @SuppressLint("ObsoleteSdkInt")
     override fun onTextContextMenuItem(id: Int): Boolean {
         if (id == android.R.id.paste) {
+            if (commitClipboardImage()) {
+                return true
+            }
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
                 return super.onTextContextMenuItem(android.R.id.pasteAsPlainText)
             } else {
@@ -95,6 +104,27 @@ open class ContentEditText : AppCompatEditText {
             }
         }
     }
+
+    private fun commitClipboardImage(): Boolean {
+        val listener = listener ?: return false
+        val clipboard: ClipboardManager = context?.getClipboardManager() ?: return false
+        val clip = clipboard.primaryClip ?: return false
+        val mimeType = clip.description.supportedImageMimeType() ?: return false
+        for (i in 0 until clip.itemCount) {
+            val uri = clip.getItemAt(i).uri ?: continue
+            val opts =
+                Bundle().apply {
+                    putBoolean(OPTION_FROM_CLIPBOARD, true)
+                    putString(OPTION_CONTENT_MIME_TYPE, mimeType)
+                }
+            listener.commitContentAsync(InputContentInfoCompat(uri, clip.description, null), 0, opts)
+            return true
+        }
+        return false
+    }
+
+    private fun ClipDescription.supportedImageMimeType(): String? =
+        mimeTypes.firstOrNull { hasMimeType(it) }
 
     override fun onCreateInputConnection(editorInfo: EditorInfo): InputConnection? {
         val ic =

--- a/app/src/test/java/one/mixin/android/widget/ContentEditTextTest.kt
+++ b/app/src/test/java/one/mixin/android/widget/ContentEditTextTest.kt
@@ -1,0 +1,55 @@
+package one.mixin.android.widget
+
+import android.content.ClipData
+import android.content.ClipDescription
+import android.content.ClipboardManager
+import android.content.Context
+import android.net.Uri
+import android.os.Bundle
+import androidx.core.view.inputmethod.InputContentInfoCompat
+import androidx.test.core.app.ApplicationProvider
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class ContentEditTextTest {
+    @Test
+    fun pasteImageFromClipboardCommitsContent() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val editText = ContentEditText(context)
+        val imageUri = Uri.parse("content://one.mixin.android.test/image.png")
+        var committedUri: Uri? = null
+        var committedOpts: Bundle? = null
+
+        editText.setCommitContentListener(
+            object : ContentEditText.OnCommitContentListener {
+                override fun commitContentAsync(
+                    inputContentInfo: InputContentInfoCompat?,
+                    flags: Int,
+                    opts: Bundle?,
+                ) {
+                    committedUri = inputContentInfo?.contentUri
+                    committedOpts = opts
+                }
+            },
+        )
+
+        val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+        clipboard.setPrimaryClip(
+            ClipData(
+                ClipDescription("image", arrayOf("image/png")),
+                ClipData.Item(imageUri),
+            ),
+        )
+
+        val handled = editText.onTextContextMenuItem(android.R.id.paste)
+
+        assertTrue(handled)
+        assertEquals(imageUri, committedUri)
+        assertTrue(committedOpts?.getBoolean(ContentEditText.OPTION_FROM_CLIPBOARD) == true)
+        assertEquals("image/png", committedOpts?.getString(ContentEditText.OPTION_CONTENT_MIME_TYPE))
+    }
+}


### PR DESCRIPTION
## Summary
- Support pasting image URIs from the system clipboard into chat input.
- Route pasted still images through the existing editable image editor before sending.
- Keep existing IME image commit behavior unchanged and add a regression test for clipboard image paste.

## Testing
- ./gradlew :app:testGooglePlayDebugUnitTest --tests one.mixin.android.widget.ContentEditTextTest --no-daemon --offline --no-configuration-cache -Dkotlin.incremental=false
- ./gradlew :app:compileGooglePlayDebugKotlin --no-daemon --offline --no-configuration-cache -Dkotlin.incremental=false