### PR TITLE
fix(media): avoid full list scan in pager

### DIFF
--- a/app/src/main/java/one/mixin/android/db/MessageDao.kt
+++ b/app/src/main/java/one/mixin/android/db/MessageDao.kt
@@ -61,8 +61,8 @@ interface MessageDao : BaseDao<Message> {
         LEFT JOIN expired_messages em ON m.id = em.message_id
         """
         private const val CHAT_CATEGORY = "('SIGNAL_TEXT', 'SIGNAL_IMAGE', 'SIGNAL_VIDEO', 'SIGNAL_STICKER', 'SIGNAL_DATA', 'SIGNAL_CONTACT', 'SIGNAL_AUDIO', 'SIGNAL_LIVE', 'SIGNAL_POST', 'SIGNAL_LOCATION', 'ENCRYPTED_TEXT', 'ENCRYPTED_IMAGE', 'ENCRYPTED_VIDEO', 'ENCRYPTED_STICKER', 'ENCRYPTED_DATA', 'ENCRYPTED_CONTACT', 'ENCRYPTED_AUDIO', 'ENCRYPTED_LIVE', 'ENCRYPTED_POST', 'ENCRYPTED_LOCATION', 'PLAIN_TEXT', 'PLAIN_IMAGE', 'PLAIN_VIDEO', 'PLAIN_DATA', 'PLAIN_STICKER', 'PLAIN_CONTACT', 'PLAIN_AUDIO', 'PLAIN_LIVE', 'PLAIN_POST', 'PLAIN_LOCATION', 'APP_BUTTON_GROUP', 'APP_CARD', 'SYSTEM_ACCOUNT_SNAPSHOT', 'SYSTEM_SAFE_SNAPSHOT')"
-        private const val APP_CARD_COVER_MEDIA = "category = 'APP_CARD'"
-        private const val APP_CARD_COVER_MEDIA_ALIAS = "m.category = 'APP_CARD'"
+        private const val APP_CARD_COVER_MEDIA = "category = 'APP_CARD' AND ((content LIKE '%\"cover_url\":\"%' AND content NOT LIKE '%\"cover_url\":\"\"%') OR (content LIKE '%\"cover\":{%\"url\":\"%' AND content NOT LIKE '%\"cover\":{%\"url\":\"\"%'))"
+        private const val APP_CARD_COVER_MEDIA_ALIAS = "m.category = 'APP_CARD' AND ((m.content LIKE '%\"cover_url\":\"%' AND m.content NOT LIKE '%\"cover_url\":\"\"%') OR (m.content LIKE '%\"cover\":{%\"url\":\"%' AND m.content NOT LIKE '%\"cover\":{%\"url\":\"\"%'))"
     }
 
     // Read SQL

--- a/app/src/main/java/one/mixin/android/db/MessageDao.kt
+++ b/app/src/main/java/one/mixin/android/db/MessageDao.kt
@@ -61,8 +61,8 @@ interface MessageDao : BaseDao<Message> {
         LEFT JOIN expired_messages em ON m.id = em.message_id
         """
         private const val CHAT_CATEGORY = "('SIGNAL_TEXT', 'SIGNAL_IMAGE', 'SIGNAL_VIDEO', 'SIGNAL_STICKER', 'SIGNAL_DATA', 'SIGNAL_CONTACT', 'SIGNAL_AUDIO', 'SIGNAL_LIVE', 'SIGNAL_POST', 'SIGNAL_LOCATION', 'ENCRYPTED_TEXT', 'ENCRYPTED_IMAGE', 'ENCRYPTED_VIDEO', 'ENCRYPTED_STICKER', 'ENCRYPTED_DATA', 'ENCRYPTED_CONTACT', 'ENCRYPTED_AUDIO', 'ENCRYPTED_LIVE', 'ENCRYPTED_POST', 'ENCRYPTED_LOCATION', 'PLAIN_TEXT', 'PLAIN_IMAGE', 'PLAIN_VIDEO', 'PLAIN_DATA', 'PLAIN_STICKER', 'PLAIN_CONTACT', 'PLAIN_AUDIO', 'PLAIN_LIVE', 'PLAIN_POST', 'PLAIN_LOCATION', 'APP_BUTTON_GROUP', 'APP_CARD', 'SYSTEM_ACCOUNT_SNAPSHOT', 'SYSTEM_SAFE_SNAPSHOT')"
-        private const val APP_CARD_COVER_MEDIA = "category = 'APP_CARD' AND ((content LIKE '%\"cover_url\":\"%' AND content NOT LIKE '%\"cover_url\":\"\"%') OR (content LIKE '%\"cover\":{%\"url\":\"%' AND content NOT LIKE '%\"cover\":{%\"url\":\"\"%'))"
-        private const val APP_CARD_COVER_MEDIA_ALIAS = "m.category = 'APP_CARD' AND ((m.content LIKE '%\"cover_url\":\"%' AND m.content NOT LIKE '%\"cover_url\":\"\"%') OR (m.content LIKE '%\"cover\":{%\"url\":\"%' AND m.content NOT LIKE '%\"cover\":{%\"url\":\"\"%'))"
+        private const val APP_CARD_COVER_MEDIA = "category = 'APP_CARD' AND content LIKE '%\"cover_url\":\"%' AND content NOT LIKE '%\"cover_url\":\"\"%'"
+        private const val APP_CARD_COVER_MEDIA_ALIAS = "m.category = 'APP_CARD' AND m.content LIKE '%\"cover_url\":\"%' AND m.content NOT LIKE '%\"cover_url\":\"\"%'"
     }
 
     // Read SQL

--- a/app/src/main/java/one/mixin/android/repository/ConversationRepository.kt
+++ b/app/src/main/java/one/mixin/android/repository/ConversationRepository.kt
@@ -62,6 +62,7 @@ import one.mixin.android.vo.ConversationStatus
 import one.mixin.android.vo.ConversationStorageUsage
 import one.mixin.android.vo.GroupInfo
 import one.mixin.android.vo.isAppCard
+import one.mixin.android.vo.isAppCardWithMediaCover
 import one.mixin.android.vo.Job
 import one.mixin.android.vo.Message
 import one.mixin.android.vo.MessageItem
@@ -250,7 +251,7 @@ class ConversationRepository
             messageId: String,
         ): MessageItem? {
             val item = messageDao.getMediaMessage(conversationId, messageId) ?: return null
-            return if (item.isAppCard() && !item.isAppCardWithCover()) null else item
+            return if (item.isAppCard() && !item.isAppCardWithMediaCover()) null else item
         }
 
         suspend fun getConversationIdIfExistsSync(recipientId: String) =

--- a/app/src/main/java/one/mixin/android/repository/ConversationRepository.kt
+++ b/app/src/main/java/one/mixin/android/repository/ConversationRepository.kt
@@ -195,27 +195,22 @@ class ConversationRepository
             conversationId: String,
             messageId: String,
             excludeLive: Boolean,
-        ): Int {
-            val list = if (excludeLive) {
-                messageDao.getMediaMessagesExcludeLiveList(conversationId)
+        ): Int =
+            if (excludeLive) {
+                messageDao.indexMediaMessagesExcludeLive(conversationId, messageId)
             } else {
-                messageDao.getMediaMessagesList(conversationId)
+                messageDao.indexMediaMessages(conversationId, messageId)
             }
-            val filteredList = list.filter { !it.isAppCard() || it.isAppCardWithCover() }
-            return filteredList.indexOfFirst { it.messageId == messageId }.coerceAtLeast(0)
-        }
 
         suspend fun countIndexMediaMessages(
             conversationId: String,
             excludeLive: Boolean,
-        ): Int {
-            val list = if (excludeLive) {
-                messageDao.getMediaMessagesExcludeLiveList(conversationId)
+        ): Int =
+            if (excludeLive) {
+                messageDao.countIndexMediaMessagesExcludeLive(conversationId)
             } else {
-                messageDao.getMediaMessagesList(conversationId)
+                messageDao.countIndexMediaMessages(conversationId)
             }
-            return list.count { !it.isAppCard() || it.isAppCardWithCover() }
-        }
 
         fun getMediaMessagesDataSource(
             conversationId: String,

--- a/app/src/main/java/one/mixin/android/ui/media/SharedMediaViewModel.kt
+++ b/app/src/main/java/one/mixin/android/ui/media/SharedMediaViewModel.kt
@@ -231,20 +231,8 @@ class SharedMediaViewModel
         conversationId: String,
         index: Int,
         excludeLive: Boolean,
-    ): LiveData<PagedList<MessageItem>> {
-        val liveData = MutableLiveData<PagedList<MessageItem>>()
-        viewModelScope.launch(Dispatchers.IO) {
-            val list = if (excludeLive) {
-                conversationRepository.getMediaMessagesExcludeLiveList(conversationId)
-            } else {
-                conversationRepository.getMediaMessagesList(conversationId)
-            }
-            val filteredList = list.filter { !it.isAppCard() || it.isAppCardWithCover() }
-            val pagedList = createPagedList(filteredList, index)
-            liveData.postValue(pagedList)
-        }
-        return liveData
-    }
+    ): LiveData<PagedList<MessageItem>> =
+        conversationRepository.getMediaMessages(conversationId, index, excludeLive)
 
     suspend fun getMediaMessage(
         conversationId: String,
@@ -282,4 +270,3 @@ class ListDataSource<T : Any>(private val items: List<T>) : PositionalDataSource
         }
     }
 }
-

--- a/app/src/main/java/one/mixin/android/ui/media/pager/MediaPagerActivity.kt
+++ b/app/src/main/java/one/mixin/android/ui/media/pager/MediaPagerActivity.kt
@@ -89,7 +89,7 @@ import one.mixin.android.vo.FixedMessageDataSource
 import one.mixin.android.vo.MediaStatus
 import one.mixin.android.vo.MessageItem
 import one.mixin.android.vo.absolutePath
-import one.mixin.android.vo.appCardCoverUrl
+import one.mixin.android.vo.appCardMediaCoverUrl
 import one.mixin.android.vo.isAppCard
 import one.mixin.android.vo.isImage
 import one.mixin.android.vo.isLive
@@ -465,7 +465,7 @@ class MediaPagerActivity : BaseActivity(), DismissFrameLayout.OnDismissListener,
 
     @OptIn(ExperimentalCoilApi::class)
     private suspend fun resolveLocalFile(item: MessageItem): File? {
-        val coverUrl = item.appCardCoverUrl()
+        val coverUrl = item.appCardMediaCoverUrl()
         if (coverUrl != null) {
             return try {
                 val loader = imageLoader

--- a/app/src/main/java/one/mixin/android/ui/media/pager/PhotoHolder.kt
+++ b/app/src/main/java/one/mixin/android/ui/media/pager/PhotoHolder.kt
@@ -11,7 +11,7 @@ import one.mixin.android.session.Session
 import one.mixin.android.vo.MediaStatus
 import one.mixin.android.vo.MessageItem
 import one.mixin.android.vo.absolutePath
-import one.mixin.android.vo.appCardCoverUrl
+import one.mixin.android.vo.appCardMediaCoverUrl
 import one.mixin.android.vo.isAppCard
 import one.mixin.android.widget.CircleProgress
 import one.mixin.android.widget.PhotoView.PhotoView
@@ -29,7 +29,7 @@ class PhotoHolder(itemView: View) : MediaPagerHolder(itemView) {
         val appCardData = messageItem.appCardData
         if (messageItem.isAppCard()) {
             imageView.loadImage(
-                messageItem.appCardCoverUrl(),
+                messageItem.appCardMediaCoverUrl(),
                 holder = R.drawable.bot_default,
                 base64Holder = appCardData?.cover?.thumbnail,
                 onSuccess = { _, _ ->

--- a/app/src/main/java/one/mixin/android/vo/AppCardData.kt
+++ b/app/src/main/java/one/mixin/android/vo/AppCardData.kt
@@ -62,6 +62,9 @@ data class AppCardData(
             return !coverUrl.isNullOrBlank() || !cover?.url.isNullOrBlank()
         }
 
+    val hasMediaCover: Boolean
+        get() = !coverUrl.isNullOrBlank()
+
     val hasValidCoverSize: Boolean
         get() {
             return cover?.let { it.width in APP_CARD_COVER_MIN_SIZE..APP_CARD_COVER_MAX_SIZE && it.height in APP_CARD_COVER_MIN_SIZE..APP_CARD_COVER_MAX_SIZE } ?: true
@@ -160,6 +163,18 @@ data class Cover(
 fun MessageItem.appCardCoverUrl(): String? =
     if (isAppCard()) {
         appCardData?.let { it.coverUrl?.takeIf(String::isNotBlank) ?: it.cover?.url?.takeIf(String::isNotBlank) }
+    } else {
+        null
+    }
+
+fun MessageItem.isAppCardWithMediaCover(): Boolean {
+    if (!isAppCard()) return false
+    return appCardData?.hasMediaCover == true
+}
+
+fun MessageItem.appCardMediaCoverUrl(): String? =
+    if (isAppCard()) {
+        appCardData?.coverUrl?.takeIf(String::isNotBlank)
     } else {
         null
     }

--- a/app/src/main/java/one/mixin/android/vo/AppCardData.kt
+++ b/app/src/main/java/one/mixin/android/vo/AppCardData.kt
@@ -59,8 +59,7 @@ data class AppCardData(
     val hashCover: Boolean
         get() {
             if (oldVersion) return false
-            if (coverUrl.isNullOrBlank()) return false
-            return true
+            return !coverUrl.isNullOrBlank() || !cover?.url.isNullOrBlank()
         }
 
     val hasValidCoverSize: Boolean

--- a/app/src/test/java/one/mixin/android/db/MessageDaoTest.kt
+++ b/app/src/test/java/one/mixin/android/db/MessageDaoTest.kt
@@ -1,0 +1,142 @@
+package one.mixin.android.db
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlinx.coroutines.runBlocking
+import one.mixin.android.vo.Conversation
+import one.mixin.android.vo.ConversationCategory
+import one.mixin.android.vo.ConversationStatus
+import one.mixin.android.vo.MediaStatus
+import one.mixin.android.vo.MessageBuilder
+import one.mixin.android.vo.MessageCategory
+import one.mixin.android.vo.MessageStatus
+import one.mixin.android.vo.User
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class MessageDaoTest {
+    private lateinit var database: MixinDatabase
+    private lateinit var messageDao: MessageDao
+
+    @BeforeTest
+    fun setUp() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        database = Room.inMemoryDatabaseBuilder(context, MixinDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        messageDao = database.messageDao()
+    }
+
+    @AfterTest
+    fun tearDown() {
+        database.close()
+    }
+
+    @Test
+    fun mediaQueriesIncludeAppCardsWithCoverUrl() = runBlocking {
+        val conversationId = "conversation-id"
+        val userId = "user-id"
+        database.conversationDao().insert(conversation(conversationId))
+        database.userDao().insert(user(userId))
+        messageDao.insertList(
+            listOf(
+                imageMessage("image-before", conversationId, userId, "2026-06-29T00:00:00Z"),
+                appCardMessage(
+                    id = "cover-url-app-card",
+                    conversationId = conversationId,
+                    userId = userId,
+                    content = """{"app_id":"app","cover_url":"https://example.com/cover-url.jpg","title":"cover url"}""",
+                    createdAt = "2026-06-29T00:01:00Z",
+                ),
+                imageMessage("target-image", conversationId, userId, "2026-06-29T00:02:00Z"),
+                appCardMessage(
+                    id = "nested-cover-app-card",
+                    conversationId = conversationId,
+                    userId = userId,
+                    content = """{"app_id":"app","cover":{"url":"https://example.com/cover.jpg","height":320,"width":640,"mime_type":"image/jpeg"},"title":"cover"}""",
+                    createdAt = "2026-06-29T00:03:00Z",
+                ),
+                appCardMessage(
+                    id = "empty-cover-app-card",
+                    conversationId = conversationId,
+                    userId = userId,
+                    content = """{"app_id":"app","cover":{},"title":"empty"}""",
+                    createdAt = "2026-06-29T00:04:00Z",
+                ),
+            ),
+        )
+
+        assertNotNull(messageDao.getMediaMessage(conversationId, "cover-url-app-card"))
+        assertNull(messageDao.getMediaMessage(conversationId, "empty-cover-app-card"))
+        assertNull(messageDao.getMediaMessage(conversationId, "nested-cover-app-card"))
+        assertEquals(
+            listOf("image-before", "cover-url-app-card", "target-image"),
+            messageDao.getMediaMessagesList(conversationId).map { it.messageId },
+        )
+        assertEquals(2, messageDao.indexMediaMessages(conversationId, "target-image"))
+        assertEquals(3, messageDao.countIndexMediaMessages(conversationId))
+    }
+
+    private fun conversation(id: String) =
+        Conversation(
+            conversationId = id,
+            ownerId = null,
+            category = ConversationCategory.CONTACT.name,
+            name = null,
+            iconUrl = null,
+            announcement = null,
+            codeUrl = null,
+            payType = null,
+            createdAt = "2026-06-29T00:00:00Z",
+            pinTime = null,
+            lastMessageId = null,
+            lastReadMessageId = null,
+            unseenMessageCount = 0,
+            status = ConversationStatus.SUCCESS.ordinal,
+        )
+
+    private fun user(id: String) =
+        User(
+            userId = id,
+            identityNumber = "1",
+            relationship = "",
+            biography = "",
+            fullName = "User",
+            avatarUrl = null,
+            phone = null,
+            isVerified = false,
+            createdAt = null,
+            muteUntil = null,
+        )
+
+    private fun imageMessage(
+        id: String,
+        conversationId: String,
+        userId: String,
+        createdAt: String,
+    ) =
+        MessageBuilder(id, conversationId, userId, MessageCategory.PLAIN_IMAGE.name, MessageStatus.SENT.name, createdAt)
+            .setMediaStatus(MediaStatus.DONE.name)
+            .setMediaWidth(100)
+            .setMediaHeight(100)
+            .build()
+
+    private fun appCardMessage(
+        id: String,
+        conversationId: String,
+        userId: String,
+        content: String,
+        createdAt: String,
+    ) =
+        MessageBuilder(id, conversationId, userId, MessageCategory.APP_CARD.name, MessageStatus.SENT.name, createdAt)
+            .setContent(content)
+            .build()
+}

--- a/app/src/test/java/one/mixin/android/vo/AppCardDataTest.kt
+++ b/app/src/test/java/one/mixin/android/vo/AppCardDataTest.kt
@@ -1,0 +1,53 @@
+package one.mixin.android.vo
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AppCardDataTest {
+    @Test
+    fun `hashCover returns true when nested cover url exists`() {
+        val appCardData = AppCardData(
+            appId = "app-id",
+            iconUrl = null,
+            coverUrl = null,
+            cover = Cover(
+                height = 320,
+                width = 640,
+                mimeType = "image/jpeg",
+                url = "https://example.com/cover.jpg",
+                thumbnail = null,
+            ),
+            title = "title",
+            description = null,
+            action = null,
+            updatedAt = null,
+            shareable = null,
+        )
+
+        assertTrue(appCardData.hashCover)
+    }
+
+    @Test
+    fun `hashCover returns false when cover urls are blank`() {
+        val appCardData = AppCardData(
+            appId = "app-id",
+            iconUrl = null,
+            coverUrl = "",
+            cover = Cover(
+                height = 320,
+                width = 640,
+                mimeType = "image/jpeg",
+                url = "",
+                thumbnail = null,
+            ),
+            title = "title",
+            description = null,
+            action = null,
+            updatedAt = null,
+            shareable = null,
+        )
+
+        assertFalse(appCardData.hashCover)
+    }
+}

--- a/app/src/test/java/one/mixin/android/vo/AppCardDataTest.kt
+++ b/app/src/test/java/one/mixin/android/vo/AppCardDataTest.kt
@@ -50,4 +50,56 @@ class AppCardDataTest {
 
         assertFalse(appCardData.hashCover)
     }
+
+    @Test
+    fun `hashCover keeps cover url compatibility`() {
+        val appCardData = AppCardData(
+            appId = "app-id",
+            iconUrl = null,
+            coverUrl = "https://example.com/cover.jpg",
+            cover = null,
+            title = "title",
+            description = null,
+            action = null,
+            updatedAt = null,
+            shareable = null,
+        )
+
+        assertTrue(appCardData.hashCover)
+    }
+
+    @Test
+    fun `hasMediaCover returns true only when cover url exists`() {
+        val coverUrlOnly = AppCardData(
+            appId = "app-id",
+            iconUrl = null,
+            coverUrl = "https://example.com/cover.jpg",
+            cover = null,
+            title = "title",
+            description = null,
+            action = null,
+            updatedAt = null,
+            shareable = null,
+        )
+        val nestedCover = AppCardData(
+            appId = "app-id",
+            iconUrl = null,
+            coverUrl = null,
+            cover = Cover(
+                height = 320,
+                width = 640,
+                mimeType = "image/jpeg",
+                url = "https://example.com/cover.jpg",
+                thumbnail = null,
+            ),
+            title = "title",
+            description = null,
+            action = null,
+            updatedAt = null,
+            shareable = null,
+        )
+
+        assertTrue(coverUrlOnly.hasMediaCover)
+        assertFalse(nestedCover.hasMediaCover)
+    }
 }


### PR DESCRIPTION
## Summary
- avoid loading all media messages when computing media pager index/count
- keep app card cover SQL filtering aligned with nested cover url support
- add AppCardData regression test for nested cover urls

## Testing
- ./gradlew :app:testGooglePlayDebugUnitTest --tests one.mixin.android.vo.AppCardDataTest