### PR TITLE
fix(web): keep webview open for walletconnect

### DIFF
--- a/app/src/main/java/one/mixin/android/ui/web/WebFragment.kt
+++ b/app/src/main/java/one/mixin/android/ui/web/WebFragment.kt
@@ -1886,9 +1886,6 @@ class WebFragment : BaseFragment() {
                 if (wcUrl != null) {
                     // handle wallet connect url
                     UrlInterpreterActivity.show(view.context, wcUrl)
-                    if (request.isForMainFrame) {
-                        closeWebContainer()
-                    }
                 }
                 // ignore wallet connect data url
                 return true


### PR DESCRIPTION
## Summary
- keep WebFragment open when handling WalletConnect URLs
- leave other external scheme handling unchanged

## Test
- ./gradlew :app:compileGooglePlayDebugKotlin