### PR TITLE
fix(landing): format set pin error summaries

### DIFF
--- a/app/src/main/java/one/mixin/android/ui/landing/SetPinErrorMessage.kt
+++ b/app/src/main/java/one/mixin/android/ui/landing/SetPinErrorMessage.kt
@@ -1,0 +1,32 @@
+package one.mixin.android.ui.landing
+
+private const val MAX_SET_PIN_ERROR_MESSAGE_LENGTH = 320
+private const val MAX_SET_PIN_ERROR_MESSAGE_LINES = 3
+
+private val STACK_TRACE_LINE_PATTERN = Regex("""^\s*at\s+[\w.$]+\(""")
+private val INLINE_STACK_TRACE_PATTERN = Regex("""\s+at\s+[\w.$]+\(.*$""")
+private val R8_MAP_LOCATION_PATTERN = Regex("""\(r8-map-id-[^)]+\)""")
+
+internal fun String.toSetPinErrorMessage(fallbackMessage: String): String {
+    val message =
+        lineSequence()
+            .map { line ->
+                line
+                    .replace(INLINE_STACK_TRACE_PATTERN, "")
+                    .replace(R8_MAP_LOCATION_PATTERN, "")
+                    .trim()
+            }
+            .filter { line ->
+                line.isNotBlank() && !STACK_TRACE_LINE_PATTERN.containsMatchIn(line)
+            }
+            .take(MAX_SET_PIN_ERROR_MESSAGE_LINES)
+            .joinToString("\n")
+            .trim()
+            .takeWithEllipsis(MAX_SET_PIN_ERROR_MESSAGE_LENGTH)
+    return message.ifBlank { fallbackMessage }
+}
+
+private fun String.takeWithEllipsis(maxLength: Int): String {
+    if (length <= maxLength) return this
+    return take(maxLength - 3).trimEnd() + "..."
+}

--- a/app/src/main/java/one/mixin/android/ui/landing/components/SetPinLoadingPage.kt
+++ b/app/src/main/java/one/mixin/android/ui/landing/components/SetPinLoadingPage.kt
@@ -36,6 +36,7 @@ import one.mixin.android.R
 import one.mixin.android.compose.theme.MixinAppTheme
 import one.mixin.android.extension.openUrl
 import one.mixin.android.ui.landing.SetupPinViewModel
+import one.mixin.android.ui.landing.toSetPinErrorMessage
 import one.mixin.android.ui.landing.vo.SetupState
 import one.mixin.android.ui.tip.LegacyPIN
 import one.mixin.android.ui.tip.Processing
@@ -69,6 +70,7 @@ fun SetPinLoadingPage(
         }
     }
 
+    val setupPinErrorMessage = stringResource(R.string.Set_up_pin_error_message)
     val statusMessage =
         when (val step = tipStep) {
             TryConnecting -> stringResource(R.string.Trying_connect_tip_network)
@@ -90,10 +92,10 @@ fun SetPinLoadingPage(
                 }
                 append(stringResource(R.string.Connect_to_TIP_network_failed))
             }
-            is RetryProcess -> step.reason
-            is RetryRegister -> step.reason
-            is LegacyPIN -> step.message
-            else -> stringResource(R.string.Set_up_pin_error_message)
+            is RetryProcess -> step.reason.toSetPinErrorMessage(setupPinErrorMessage)
+            is RetryRegister -> step.reason.toSetPinErrorMessage(setupPinErrorMessage)
+            is LegacyPIN -> step.message.toSetPinErrorMessage(setupPinErrorMessage)
+            else -> setupPinErrorMessage
         }
     val statusColor =
         when (tipStep) {

--- a/app/src/test/java/one/mixin/android/ui/landing/SetPinErrorMessageTest.kt
+++ b/app/src/test/java/one/mixin/android/ui/landing/SetPinErrorMessageTest.kt
@@ -1,0 +1,58 @@
+package one.mixin.android.ui.landing
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class SetPinErrorMessageTest {
+    @Test
+    fun technicalErrorKeepsSummaryAndDropsStackTrace() {
+        val message =
+            """
+            Set or update PIN failed
+            java.lang.IllegalArgumentException: required oldPin can not be null
+                at one.mixin.android.ui.tip.TipFlowInteractor.process(r8-map-id-c64e16044f75583ed76647c657465991d5ea4242af7c39ecafdd2fe8481b2cde:24)
+                at one.mixin.android.ui.landing.SetupPinViewModel${'$'}executeCreatePin${'$'}1.invokeSuspend(r8-map-id-c64e16044f75583ed76647c657465991d5ea4242af7c39ecafdd2fe8481b2cde:108)
+            """.trimIndent()
+
+        assertEquals(
+            "Set or update PIN failed\njava.lang.IllegalArgumentException: required oldPin can not be null",
+            message.toSetPinErrorMessage(
+                fallbackMessage = "Failed to set up PIN. Please check your network connection and try again.",
+            ),
+        )
+    }
+
+    @Test
+    fun readableErrorIsKept() {
+        assertEquals(
+            "PIN incorrect",
+            "PIN incorrect".toSetPinErrorMessage(
+                fallbackMessage = "Failed to set up PIN. Please check your network connection and try again.",
+            ),
+        )
+    }
+
+    @Test
+    fun coroutineExceptionSummaryIsKept() {
+        assertEquals(
+            "Set or update PIN failed kotlinx.coroutines.JobCancellationException",
+            "Set or update PIN failed kotlinx.coroutines.JobCancellationException".toSetPinErrorMessage(
+                fallbackMessage = "Failed to set up PIN. Please check your network connection and try again.",
+            ),
+        )
+    }
+
+    @Test
+    fun inlineStackTraceIsDropped() {
+        val message =
+            "Set or update PIN failed java.io.IOException: net::ERR_NAME_NOT_RESOLVED " +
+                "at org.bitcoinj.script.ScriptBuilder.getResponse(r8-map-id-c64e16044f75583ed76647c657465991d5ea4242af7c39ecafdd2fe8481b2cde:164)"
+
+        assertEquals(
+            "Set or update PIN failed java.io.IOException: net::ERR_NAME_NOT_RESOLVED",
+            message.toSetPinErrorMessage(
+                fallbackMessage = "Failed to set up PIN. Please check your network connection and try again.",
+            ),
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Format setup PIN failure messages before displaying them on the loading page
- Preserve short failure summaries while removing stack frames and r8 mapping details
- Add regression coverage for multiline and inline stack traces

## Test
- ./gradlew :app:testGooglePlayDebugUnitTest --tests one.mixin.android.ui.landing.SetPinErrorMessageTest
- git diff --check