### PR TITLE
Fix Curve25519 16 KB page-size compatibility

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -167,7 +167,6 @@ android {
         }
         jniLibs {
             useLegacyPackaging = true
-            excludes += setOf("lib/x86_64/libcurve25519.so")
         }
     }
 
@@ -462,7 +461,7 @@ dependencies {
     implementation("com.google.android.gms:play-services-cronet:$googlePlayServicesVersion")
     implementation("com.google.zxing:core:$zxingVersion")
     implementation("com.github.tougee:sticky-headers-recyclerview:$stickyHeadersRecyclerViewVersion")
-    implementation("org.whispersystems:signal-protocol-android:$signalVersion")
+    implementation("org.whispersystems:signal-protocol-java:$signalVersion")
     implementation("org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutinesVersion")

--- a/app/src/main/java/one/mixin/android/util/NativeLoader.kt
+++ b/app/src/main/java/one/mixin/android/util/NativeLoader.kt
@@ -10,7 +10,7 @@ import java.io.FileOutputStream
 import java.util.zip.ZipEntry
 import java.util.zip.ZipFile
 
-private val libNames = listOf("mixin", "argon2jni", "argon2native", "barhopper_v3", "rlottie", "gojni", "curve25519")
+private val libNames = listOf("mixin", "argon2jni", "argon2native", "barhopper_v3", "rlottie", "gojni")
 private val libSoNames = libNames.map { "lib$it.so" }
 private val localLibSoNames = libNames.map { "lib${it}loc.so" }
 private val nativeLoadedList = libNames.map { false }.toMutableList()


### PR DESCRIPTION
## Summary

- replace `signal-protocol-android` with the same-version `signal-protocol-java` provider
- stop loading the removed `libcurve25519.so` from `NativeLoader`
- remove the obsolete x86_64 packaging exclusion

The Android artifact packages a legacy Curve25519 native library built with an obsolete toolchain. Using the Java provider preserves the Signal Protocol API/version while removing the native payload flagged by Play for 16 KB page-size compatibility.

## Verification

- `:app:testGooglePlayDebugUnitTest --tests one.mixin.android.util.CryptoUtilTest`
- `:app:connectedGooglePlayDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=one.mixin.android.util.EncryptedProtocolTest` (5/5 passed)
- `:app:bundleGooglePlayRelease`
- verified the release AAB contains no `libcurve25519.so` for any ABI
- verified the release dependency graph resolves `curve25519-java` only