### PR TITLE
fix(perps): handle liquidation price request failures

### DIFF
--- a/app/src/main/java/one/mixin/android/ui/home/web3/trade/perps/LiquidationPriceRequest.kt
+++ b/app/src/main/java/one/mixin/android/ui/home/web3/trade/perps/LiquidationPriceRequest.kt
@@ -1,0 +1,46 @@
+package one.mixin.android.ui.home.web3.trade.perps
+
+import kotlinx.coroutines.delay
+import java.math.BigDecimal
+
+internal sealed interface LiquidationPriceResult {
+    data class Success(val price: String) : LiquidationPriceResult
+
+    data object Retry : LiquidationPriceResult
+
+    data object Failure : LiquidationPriceResult
+}
+
+internal fun liquidationPriceResult(
+    price: String?,
+    errorCode: Int?,
+): LiquidationPriceResult {
+    val validPrice = price?.takeIf { it.isNotBlank() }
+    return when {
+        validPrice != null -> LiquidationPriceResult.Success(validPrice)
+        errorCode == 500 -> LiquidationPriceResult.Retry
+        else -> LiquidationPriceResult.Failure
+    }
+}
+
+internal fun shouldRequestLiquidationPrice(
+    amount: BigDecimal?,
+    minimumAmount: BigDecimal,
+): Boolean {
+    return amount != null &&
+        amount > BigDecimal.ZERO &&
+        (minimumAmount <= BigDecimal.ZERO || amount >= minimumAmount)
+}
+
+internal suspend fun requestLiquidationPrice(
+    retryDelayMillis: Long = 1000L,
+    request: suspend () -> LiquidationPriceResult,
+): String? {
+    while (true) {
+        when (val result = request()) {
+            LiquidationPriceResult.Failure -> return null
+            LiquidationPriceResult.Retry -> delay(retryDelayMillis)
+            is LiquidationPriceResult.Success -> return result.price
+        }
+    }
+}

--- a/app/src/main/java/one/mixin/android/ui/home/web3/trade/perps/OpenPositionPage.kt
+++ b/app/src/main/java/one/mixin/android/ui/home/web3/trade/perps/OpenPositionPage.kt
@@ -220,35 +220,33 @@ fun OpenPositionPage(
         }
     }
 
-    LaunchedEffect(usdtAmount, leverage) {
+    LaunchedEffect(usdtAmount, leverage, currentMarket.minAmount) {
         val amount = usdtAmount.toBigDecimalOrNull()
-        if (amount == null || amount <= BigDecimal.ZERO) {
+        val minimumAmount = currentMarket.minAmount.toBigDecimalOrNull() ?: BigDecimal.ZERO
+        if (!shouldRequestLiquidationPrice(amount, minimumAmount)) {
             remoteLiquidationPrice = null
             isLiquidationLoading = false
             return@LaunchedEffect
         }
+        val requestAmount = amount ?: return@LaunchedEffect
         liquidationJob?.cancel()
         liquidationJob = launch {
+            remoteLiquidationPrice = null
             isLiquidationLoading = true
             delay(200L)
-            while (true) {
-                val normalizedAmount = amount
-                    .stripTrailingZeros()
-                    .toPlainString()
-                    .let { limitTradeInputDecimalPlaces(it, TRADE_INPUT_MAX_DECIMAL_PLACES) }
-                val result = viewModel.estimateLiquidationPrice(
+            val normalizedAmount = requestAmount
+                .stripTrailingZeros()
+                .toPlainString()
+                .let { limitTradeInputDecimalPlaces(it, TRADE_INPUT_MAX_DECIMAL_PLACES) }
+            remoteLiquidationPrice = requestLiquidationPrice {
+                viewModel.estimateLiquidationPrice(
                     marketId = currentMarket.marketId,
                     amount = normalizedAmount,
                     side = if (isLong) "long" else "short",
                     leverage = leverage.toInt(),
                 )
-                if (result != null) {
-                    remoteLiquidationPrice = result
-                    isLiquidationLoading = false
-                    break
-                }
-                delay(1000L)
             }
+            isLiquidationLoading = false
         }
     }
 

--- a/app/src/main/java/one/mixin/android/ui/home/web3/trade/perps/PerpetualViewModel.kt
+++ b/app/src/main/java/one/mixin/android/ui/home/web3/trade/perps/PerpetualViewModel.kt
@@ -8,6 +8,7 @@ import androidx.paging.PagingData
 import androidx.paging.cachedIn
 import androidx.room.withTransaction
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
@@ -43,6 +44,7 @@ import one.mixin.android.job.RefreshTokensJob
 import one.mixin.android.util.ErrorHandler
 import one.mixin.android.util.getMixinErrorStringByCode
 import one.mixin.android.vo.safe.TokenItem
+import retrofit2.HttpException
 import timber.log.Timber
 import java.math.BigDecimal
 import java.text.SimpleDateFormat
@@ -355,13 +357,13 @@ class PerpetualViewModel @Inject constructor(
         }
     }
 
-    suspend fun estimateLiquidationPrice(
+    internal suspend fun estimateLiquidationPrice(
         amount: String,
         marketId: String? = null,
         side: String? = null,
         leverage: Int? = null,
         positionId: String? = null,
-    ): String? {
+    ): LiquidationPriceResult {
         return try {
             val response = withContext(Dispatchers.IO) {
                 routeService.getPerpsLiquidationPrice(
@@ -373,14 +375,25 @@ class PerpetualViewModel @Inject constructor(
                 )
             }
             if (response.isSuccess) {
-                response.data?.liquidationPrice?.takeIf { it.isNotBlank() }
+                liquidationPriceResult(
+                    price = response.data?.liquidationPrice,
+                    errorCode = null,
+                )
             } else {
                 Timber.e("Failed to estimate liquidation price: ${response.errorDescription}")
-                null
+                liquidationPriceResult(
+                    price = null,
+                    errorCode = response.errorCode,
+                )
             }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: HttpException) {
+            Timber.e(e, "HTTP error estimating liquidation price")
+            liquidationPriceResult(price = null, errorCode = e.code())
         } catch (e: Exception) {
             Timber.e(e, "Error estimating liquidation price")
-            null
+            LiquidationPriceResult.Failure
         }
     }
 

--- a/app/src/main/java/one/mixin/android/ui/home/web3/trade/perps/PerpsAddBottomSheetDialogFragment.kt
+++ b/app/src/main/java/one/mixin/android/ui/home/web3/trade/perps/PerpsAddBottomSheetDialogFragment.kt
@@ -298,32 +298,29 @@ private fun PerpsAddContent(
 
     LaunchedEffect(amount, belowMinimumMargin, aboveMaximumMargin) {
         val addMargin = amount.toBigDecimalOrNull()
-        if (addMargin == null || addMargin <= BigDecimal.ZERO || belowMinimumMargin || aboveMaximumMargin) {
+        if (!shouldRequestLiquidationPrice(addMargin, minimumMargin) || aboveMaximumMargin) {
             liquidationJob?.cancel()
             remoteLiquidationPrice = null
             isLiquidationLoading = false
             return@LaunchedEffect
         }
+        val requestAmount = addMargin ?: return@LaunchedEffect
         liquidationJob?.cancel()
         liquidationJob = launch {
+            remoteLiquidationPrice = null
             isLiquidationLoading = true
             delay(200L)
-            while (true) {
-                val normalizedAmount = addMargin
-                    .stripTrailingZeros()
-                    .toPlainString()
-                    .let { limitTradeInputDecimalPlaces(it, TRADE_INPUT_MAX_DECIMAL_PLACES) }
-                val result = viewModel.estimateLiquidationPrice(
+            val normalizedAmount = requestAmount
+                .stripTrailingZeros()
+                .toPlainString()
+                .let { limitTradeInputDecimalPlaces(it, TRADE_INPUT_MAX_DECIMAL_PLACES) }
+            remoteLiquidationPrice = requestLiquidationPrice {
+                viewModel.estimateLiquidationPrice(
                     amount = normalizedAmount,
                     positionId = position.positionId,
                 )
-                if (result != null) {
-                    remoteLiquidationPrice = result
-                    isLiquidationLoading = false
-                    break
-                }
-                delay(1000L)
-            }
+            } ?: "-"
+            isLiquidationLoading = false
         }
     }
 

--- a/app/src/test/java/one/mixin/android/ui/home/web3/trade/perps/LiquidationPriceRequestTest.kt
+++ b/app/src/test/java/one/mixin/android/ui/home/web3/trade/perps/LiquidationPriceRequestTest.kt
@@ -1,0 +1,70 @@
+package one.mixin.android.ui.home.web3.trade.perps
+
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Test
+import java.math.BigDecimal
+
+class LiquidationPriceRequestTest {
+    @Test
+    fun nonServerErrorStopsAfterOneRequest() = runBlocking {
+        var requestCount = 0
+
+        val price = requestLiquidationPrice(retryDelayMillis = 0L) {
+            requestCount += 1
+            LiquidationPriceResult.Failure
+        }
+
+        assertNull(price)
+        assertEquals(1, requestCount)
+    }
+
+    @Test
+    fun serverErrorRetriesUntilSuccess() = runBlocking {
+        var requestCount = 0
+
+        val price = requestLiquidationPrice(retryDelayMillis = 0L) {
+            requestCount += 1
+            if (requestCount == 1) {
+                LiquidationPriceResult.Retry
+            } else {
+                LiquidationPriceResult.Success("123.45")
+            }
+        }
+
+        assertEquals("123.45", price)
+        assertEquals(2, requestCount)
+    }
+
+    @Test
+    fun responseCodeControlsRetry() {
+        assertSame(
+            LiquidationPriceResult.Retry,
+            liquidationPriceResult(price = null, errorCode = 500),
+        )
+        assertSame(
+            LiquidationPriceResult.Failure,
+            liquidationPriceResult(price = null, errorCode = 400),
+        )
+    }
+
+    @Test
+    fun amountBelowMinimumSkipsRequest() {
+        assertEquals(
+            false,
+            shouldRequestLiquidationPrice(
+                amount = BigDecimal("9.99"),
+                minimumAmount = BigDecimal.TEN,
+            ),
+        )
+        assertEquals(
+            true,
+            shouldRequestLiquidationPrice(
+                amount = BigDecimal.TEN,
+                minimumAmount = BigDecimal.TEN,
+            ),
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- retry liquidation price estimates only when the API returns error code 500
- stop after non-500 failures and display `-` on open/add position screens
- skip liquidation price requests when the entered margin is below `minAmount`
- share the retry policy between both screens and cover it with unit tests

## Root cause

Both position screens treated every failed estimate as a temporary failure and retried indefinitely. The ViewModel returned only a nullable price, so callers could not distinguish server errors from non-retryable failures.

## User impact

Open and add-position screens no longer repeatedly request liquidation prices for non-500 errors, and invalid below-minimum amounts do not trigger the estimate API.

## Validation

- `./gradlew :app:testGooglePlayDebugUnitTest --tests one.mixin.android.ui.home.web3.trade.perps.LiquidationPriceRequestTest`