### PR TITLE
fix(solana): validate rent balance after transfer

### DIFF
--- a/app/src/main/java/one/mixin/android/ui/home/web3/GasCheckBottomSheetDialogFragment.kt
+++ b/app/src/main/java/one/mixin/android/ui/home/web3/GasCheckBottomSheetDialogFragment.kt
@@ -439,7 +439,7 @@ class GasCheckBottomSheetDialogFragment : BottomSheetDialogFragment() {
             feeToken = feeToken,
             feeAmount = fee,
             recipientAccountState = recipientState,
-            allowZeroBalance = false,
+            allowZeroBalance = transferToken.isNativeSolAsset(),
             includeAtaCreationReserve = !transferToken.isNativeSolAsset(),
         )
 

--- a/app/src/main/java/one/mixin/android/ui/home/web3/trade/SwapContent.kt
+++ b/app/src/main/java/one/mixin/android/ui/home/web3/trade/SwapContent.kt
@@ -85,7 +85,6 @@ import one.mixin.android.util.getMixinErrorStringByCode
 import one.mixin.android.vo.market.MarketItem
 import one.mixin.android.web3.SOLANA_RENT_EXEMPTION
 import one.mixin.android.web3.isNativeSolAsset
-import one.mixin.android.web3.nativeSolSpendableBalance
 import java.math.BigDecimal
 
 @Composable
@@ -160,19 +159,6 @@ fun SwapContent(
                 fromToken?.let { from ->
                     toToken?.let { to ->
                         val amount = runCatching { BigDecimal(text) }.getOrDefault(BigDecimal.ZERO)
-                        val isNativeSolRentError = isNativeSolSwapAmountBelowRent(
-                            inputText = text,
-                            isNativeSol = from.isNativeSolAsset(),
-                            inMixin = inMixin,
-                        )
-                        if (isNativeSolRentError) {
-                            quoteError = null
-                            quoteResult = null
-                            quoteMin = null
-                            quoteMax = null
-                            isLoading = false
-                            return@collectLatest
-                        }
                         if (reviewing) {
                             isLoading = false
                             return@collectLatest
@@ -216,10 +202,11 @@ fun SwapContent(
     fromToken?.let { from ->
         val fromBalance = viewModel.tokenExtraFlow(from).collectAsStateWithLifecycle(from.balance).value
         val rawFromBalanceValue = fromBalance?.toBigDecimalOrNull() ?: BigDecimal.ZERO
-        val availableFromBalanceValue = swapSpendableBalance(
-            rawBalance = rawFromBalanceValue,
+        val availableFromBalanceValue = rawFromBalanceValue
+        val isNativeSolBalanceError = isNativeSolSwapBalanceError(
+            inputText = inputText,
+            balance = rawFromBalanceValue,
             isNativeSol = from.isNativeSolAsset(),
-            inMixin = inMixin,
         )
         val availableFromBalance = availableFromBalanceValue.stripTrailingZeros().toPlainString()
 
@@ -347,11 +334,7 @@ fun SwapContent(
                                         toToken = toToken,
                                         isLoading = isLoading,
                                         inputText = inputText,
-                                        isNativeSolRentError = isNativeSolSwapAmountBelowRent(
-                                            inputText = inputText,
-                                            isNativeSol = from.isNativeSolAsset(),
-                                            inMixin = inMixin,
-                                        ),
+                                        isNativeSolBalanceError = isNativeSolBalanceError,
                                         quoteMin = quoteMin,
                                         quoteMax = quoteMax,
                                         onInputTextChange = {
@@ -392,11 +375,7 @@ fun SwapContent(
                             fromToken = fromToken!!,
                             quoteResult = quoteResult,
                             quoteError = quoteError,
-                            isNativeSolRentError = isNativeSolSwapAmountBelowRent(
-                                inputText = inputText,
-                                isNativeSol = from.isNativeSolAsset(),
-                                inMixin = inMixin,
-                            ),
+                            isNativeSolBalanceError = isNativeSolBalanceError,
                             isLoading = isLoading,
                             reviewing = reviewing,
                             isButtonEnabled = isButtonEnabled,
@@ -461,24 +440,16 @@ internal fun shouldShowSwapRecommendedMarketCards(
     isKeyboardVisible: Boolean,
 ): Boolean = inMixin && hasRecommendedCards && inputText.isBlank() && !isSendFocused && !isKeyboardVisible
 
-internal fun swapSpendableBalance(
-    rawBalance: BigDecimal,
-    isNativeSol: Boolean,
-    inMixin: Boolean,
-): BigDecimal {
-    if (inMixin) return rawBalance
-    if (!isNativeSol) return rawBalance
-    return nativeSolSpendableBalance(rawBalance)
-}
-
-internal fun isNativeSolSwapAmountBelowRent(
+internal fun isNativeSolSwapBalanceError(
     inputText: String,
+    balance: BigDecimal,
     isNativeSol: Boolean,
-    inMixin: Boolean,
 ): Boolean {
-    if (!isNativeSol || !inMixin) return false
+    if (!isNativeSol) return false
     val amount = inputText.toBigDecimalOrNull() ?: return false
-    return amount > BigDecimal.ZERO && amount < SOLANA_RENT_EXEMPTION
+    if (amount <= BigDecimal.ZERO || amount > balance) return false
+    val remaining = balance.subtract(amount)
+    return remaining > BigDecimal.ZERO && remaining < SOLANA_RENT_EXEMPTION
 }
 
 internal fun shouldResetSwapSendFocusState(
@@ -493,7 +464,7 @@ fun ReviewButton(
     fromToken: SwapToken,
     quoteResult: QuoteResult?,
     quoteError: Throwable?,
-    isNativeSolRentError: Boolean,
+    isNativeSolBalanceError: Boolean,
     isLoading: Boolean,
     reviewing: Boolean,
     isButtonEnabled: Boolean,
@@ -506,7 +477,7 @@ fun ReviewButton(
     val checkBalance = checkBalance(inputText, fromBalance)
     val isBusy = isLoading || reviewing
     val hasError = quoteError != null
-    val canReview = quoteResult != null && !hasError && !isBusy && checkBalance == true && !isNativeSolRentError
+    val canReview = quoteResult != null && !hasError && !isBusy && checkBalance == true && !isNativeSolBalanceError
     Button(
         modifier = Modifier
             .padding(horizontal = 20.dp)
@@ -611,7 +582,7 @@ fun QuoteInfoBox(
     toToken: SwapToken?,
     isLoading: Boolean,
     inputText: String,
-    isNativeSolRentError: Boolean,
+    isNativeSolBalanceError: Boolean,
     quoteMin: String?,
     quoteMax: String?,
     onInputTextChange: (String) -> Unit,
@@ -619,8 +590,8 @@ fun QuoteInfoBox(
     onSwitchToLimitOrder: (String, SwapToken, SwapToken) -> Unit,
 ) {
     val context = LocalContext.current
-    val displayedErrorInfo = remember(quoteError, quoteMax, inputText, isNativeSolRentError) {
-        if (isNativeSolRentError) {
+    val displayedErrorInfo = remember(quoteError, quoteMax, inputText, isNativeSolBalanceError) {
+        if (isNativeSolBalanceError) {
             context.getString(
                 R.string.send_sol_for_rent,
                 SOLANA_RENT_EXEMPTION.stripTrailingZeros().toPlainString(),
@@ -680,7 +651,7 @@ fun QuoteInfoBox(
                     ),
                 )
                 val mixinError: TradeQuoteMixinErrorException? = quoteError as? TradeQuoteMixinErrorException
-                val canSwitchToLimitOrder: Boolean = if (isNativeSolRentError || mixinError == null) {
+                val canSwitchToLimitOrder: Boolean = if (isNativeSolBalanceError || mixinError == null) {
                     false
                 } else if (mixinError.code == ErrorHandler.INVALID_QUOTE_AMOUNT) {
                     isInputGreaterThanQuoteMax(inputText, mixinError.max)

--- a/app/src/main/java/one/mixin/android/ui/home/web3/trade/SwapContent.kt
+++ b/app/src/main/java/one/mixin/android/ui/home/web3/trade/SwapContent.kt
@@ -83,6 +83,7 @@ import one.mixin.android.util.analytics.AnalyticsTracker
 import one.mixin.android.util.GsonHelper
 import one.mixin.android.util.getMixinErrorStringByCode
 import one.mixin.android.vo.market.MarketItem
+import one.mixin.android.web3.SOLANA_RENT_EXEMPTION
 import one.mixin.android.web3.isNativeSolAsset
 import one.mixin.android.web3.nativeSolSpendableBalance
 import java.math.BigDecimal
@@ -159,6 +160,19 @@ fun SwapContent(
                 fromToken?.let { from ->
                     toToken?.let { to ->
                         val amount = runCatching { BigDecimal(text) }.getOrDefault(BigDecimal.ZERO)
+                        val isNativeSolRentError = isNativeSolSwapAmountBelowRent(
+                            inputText = text,
+                            isNativeSol = from.isNativeSolAsset(),
+                            inMixin = inMixin,
+                        )
+                        if (isNativeSolRentError) {
+                            quoteError = null
+                            quoteResult = null
+                            quoteMin = null
+                            quoteMax = null
+                            isLoading = false
+                            return@collectLatest
+                        }
                         if (reviewing) {
                             isLoading = false
                             return@collectLatest
@@ -333,6 +347,11 @@ fun SwapContent(
                                         toToken = toToken,
                                         isLoading = isLoading,
                                         inputText = inputText,
+                                        isNativeSolRentError = isNativeSolSwapAmountBelowRent(
+                                            inputText = inputText,
+                                            isNativeSol = from.isNativeSolAsset(),
+                                            inMixin = inMixin,
+                                        ),
                                         quoteMin = quoteMin,
                                         quoteMax = quoteMax,
                                         onInputTextChange = {
@@ -373,6 +392,11 @@ fun SwapContent(
                             fromToken = fromToken!!,
                             quoteResult = quoteResult,
                             quoteError = quoteError,
+                            isNativeSolRentError = isNativeSolSwapAmountBelowRent(
+                                inputText = inputText,
+                                isNativeSol = from.isNativeSolAsset(),
+                                inMixin = inMixin,
+                            ),
                             isLoading = isLoading,
                             reviewing = reviewing,
                             isButtonEnabled = isButtonEnabled,
@@ -447,6 +471,16 @@ internal fun swapSpendableBalance(
     return nativeSolSpendableBalance(rawBalance)
 }
 
+internal fun isNativeSolSwapAmountBelowRent(
+    inputText: String,
+    isNativeSol: Boolean,
+    inMixin: Boolean,
+): Boolean {
+    if (!isNativeSol || !inMixin) return false
+    val amount = inputText.toBigDecimalOrNull() ?: return false
+    return amount > BigDecimal.ZERO && amount < SOLANA_RENT_EXEMPTION
+}
+
 internal fun shouldResetSwapSendFocusState(
     inputText: String,
     isKeyboardVisible: Boolean,
@@ -459,6 +493,7 @@ fun ReviewButton(
     fromToken: SwapToken,
     quoteResult: QuoteResult?,
     quoteError: Throwable?,
+    isNativeSolRentError: Boolean,
     isLoading: Boolean,
     reviewing: Boolean,
     isButtonEnabled: Boolean,
@@ -471,6 +506,7 @@ fun ReviewButton(
     val checkBalance = checkBalance(inputText, fromBalance)
     val isBusy = isLoading || reviewing
     val hasError = quoteError != null
+    val canReview = quoteResult != null && !hasError && !isBusy && checkBalance == true && !isNativeSolRentError
     Button(
         modifier = Modifier
             .padding(horizontal = 20.dp)
@@ -488,9 +524,9 @@ fun ReviewButton(
                 }
             }
         },
-        enabled = quoteResult != null && !hasError && !isBusy && checkBalance == true,
+        enabled = canReview,
         colors = ButtonDefaults.outlinedButtonColors(
-            backgroundColor = if (quoteResult != null && !hasError && checkBalance == true) {
+            backgroundColor = if (canReview) {
                 MixinAppTheme.colors.accent
             } else {
                 MixinAppTheme.colors.backgroundGrayLight
@@ -507,7 +543,7 @@ fun ReviewButton(
         if (isBusy) {
             CircularProgressIndicator(
                 modifier = Modifier.size(18.dp),
-                color = if (quoteResult != null && !hasError && checkBalance == true) {
+                color = if (canReview) {
                     Color.White
                 } else {
                     MixinAppTheme.colors.textAssist
@@ -520,7 +556,7 @@ fun ReviewButton(
                 } else {
                     stringResource(R.string.Review_Order)
                 },
-                color = if (checkBalance != true || hasError) {
+                color = if (!canReview) {
                     MixinAppTheme.colors.textAssist
                 } else {
                     Color.White
@@ -575,6 +611,7 @@ fun QuoteInfoBox(
     toToken: SwapToken?,
     isLoading: Boolean,
     inputText: String,
+    isNativeSolRentError: Boolean,
     quoteMin: String?,
     quoteMax: String?,
     onInputTextChange: (String) -> Unit,
@@ -582,8 +619,15 @@ fun QuoteInfoBox(
     onSwitchToLimitOrder: (String, SwapToken, SwapToken) -> Unit,
 ) {
     val context = LocalContext.current
-    val displayedErrorInfo = remember(quoteError, quoteMax, inputText) {
-        buildSwapDisplayedErrorInfo(context, quoteError, quoteMax, inputText)
+    val displayedErrorInfo = remember(quoteError, quoteMax, inputText, isNativeSolRentError) {
+        if (isNativeSolRentError) {
+            context.getString(
+                R.string.send_sol_for_rent,
+                SOLANA_RENT_EXEMPTION.stripTrailingZeros().toPlainString(),
+            )
+        } else {
+            buildSwapDisplayedErrorInfo(context, quoteError, quoteMax, inputText)
+        }
     }
     Box(
         modifier = if (availableHeight == null) Modifier.heightIn(48.dp) else Modifier
@@ -636,7 +680,7 @@ fun QuoteInfoBox(
                     ),
                 )
                 val mixinError: TradeQuoteMixinErrorException? = quoteError as? TradeQuoteMixinErrorException
-                val canSwitchToLimitOrder: Boolean = if (mixinError == null) {
+                val canSwitchToLimitOrder: Boolean = if (isNativeSolRentError || mixinError == null) {
                     false
                 } else if (mixinError.code == ErrorHandler.INVALID_QUOTE_AMOUNT) {
                     isInputGreaterThanQuoteMax(inputText, mixinError.max)

--- a/app/src/main/java/one/mixin/android/ui/home/web3/trade/TradeFragment.kt
+++ b/app/src/main/java/one/mixin/android/ui/home/web3/trade/TradeFragment.kt
@@ -116,8 +116,8 @@ import one.mixin.android.web3.isNativeSolAsset
 import one.mixin.android.web3.js.JsSignMessage
 import one.mixin.android.web3.js.Web3Signer
 import one.mixin.android.web3.receive.Web3AddressFragment
-import one.mixin.android.web3.requiredSolBalance
 import one.mixin.android.web3.solanaRecipientAccountState
+import one.mixin.android.web3.solanaTransferAmountRange
 import one.mixin.android.web3.swap.SwapTokenListBottomSheetDialogFragment
 import timber.log.Timber
 import java.math.BigDecimal
@@ -1095,23 +1095,20 @@ class TradeFragment : BaseFragment() {
         )
         val fee = estimate.fee
         if (fee == null) {
-            val fallbackRequiredBalance = if (usesSolRentRule) {
-                requiredSolBalance(
-                    transferAmount = transferAmount,
-                    solFee = extraSolReserve,
-                    sendingNativeSol = token.isNativeSolAsset(),
-                )
+            val insufficientByFullBalanceFallback = if (usesSolRentRule) {
+                !solanaTransferAmountRange(
+                    token = token,
+                    feeToken = chainToken,
+                    feeAmount = BigDecimal.ZERO,
+                    recipientAccountState = solanaRecipientAccountState,
+                    allowZeroBalance = token.isNativeSolAsset(),
+                    includeAtaCreationReserve = !token.isNativeSolAsset(),
+                ).canTransfer(transferAmount)
             } else if (sameAssetFee) {
-                transferAmount
+                transferAmount >= chainBalance
             } else {
-                BigDecimal.ZERO
+                false
             }
-            val insufficientByFullBalanceFallback =
-                if (usesSolRentRule) {
-                    fallbackRequiredBalance >= chainBalance
-                } else {
-                    sameAssetFee && fallbackRequiredBalance >= chainBalance
-                }
             if (!insufficientByFullBalanceFallback) {
                 return FeeCheckResult(true)
             }
@@ -1126,19 +1123,25 @@ class TradeFragment : BaseFragment() {
             return FeeCheckResult(false)
         }
         val effectiveFee = if (usesSolRentRule) fee + SOLANA_RENT_EXEMPTION + extraSolReserve else fee
-        val requiredBalance = if (usesSolRentRule) {
-            requiredSolBalance(
-                transferAmount = transferAmount,
-                solFee = fee + extraSolReserve,
-                sendingNativeSol = token.isNativeSolAsset(),
-            )
-        } else if (sameAssetFee) {
-            transferAmount + fee
+        val isBalanceSufficient = if (usesSolRentRule) {
+            solanaTransferAmountRange(
+                token = token,
+                feeToken = chainToken,
+                feeAmount = fee,
+                recipientAccountState = solanaRecipientAccountState,
+                allowZeroBalance = token.isNativeSolAsset(),
+                includeAtaCreationReserve = !token.isNativeSolAsset(),
+            ).canTransfer(transferAmount)
         } else {
-            fee
+            val requiredBalance = if (sameAssetFee) {
+                transferAmount + fee
+            } else {
+                fee
+            }
+            requiredBalance <= chainBalance
         }
 
-        if (requiredBalance <= chainBalance) {
+        if (isBalanceSufficient) {
             return FeeCheckResult(true, estimate.swapPreviewData)
         }
 

--- a/app/src/main/java/one/mixin/android/ui/wallet/InputFragment.kt
+++ b/app/src/main/java/one/mixin/android/ui/wallet/InputFragment.kt
@@ -1140,7 +1140,7 @@ class InputFragment : BaseFragment(R.layout.fragment_input), OnReceiveSelectionC
                         feeToken = feeToken,
                         feeAmount = feeAmount,
                         recipientAccountState = solanaRecipientAccountState,
-                        allowZeroBalance = false,
+                        allowZeroBalance = transferToken.isNativeSolAsset(),
                         includeAtaCreationReserve = transferToken.assetId != chainToken?.assetId,
                     )
                 }
@@ -1161,7 +1161,11 @@ class InputFragment : BaseFragment(R.layout.fragment_input), OnReceiveSelectionC
     }
 
     private fun hasCurrentSolanaRentIssue(amount: String): Boolean {
-        return isCurrentWeb3SolanaTransfer() && isBelowCurrentSolanaMinimum(amount)
+        if (!isCurrentWeb3SolanaTransfer()) return false
+        val inputAmount = amount.toBigDecimalOrNull() ?: return false
+        val range = currentSolanaTransferRange() ?: return false
+        return isBelowCurrentSolanaMinimum(amount) ||
+            (web3Token?.isNativeSolAsset() == true && range.hasNativeSolRentIssue(inputAmount))
     }
 
     private fun updateSolanaMinimumAmountHint() {

--- a/app/src/main/java/one/mixin/android/web3/SolanaTokenHelper.kt
+++ b/app/src/main/java/one/mixin/android/web3/SolanaTokenHelper.kt
@@ -20,9 +20,18 @@ enum class SolanaRecipientAccountState {
 data class SolanaTransferAmountRange(
     val minAmount: BigDecimal,
     val maxAmount: BigDecimal,
+    val nativeSolBalanceAfterFee: BigDecimal? = null,
 ) {
     fun canTransfer(amount: BigDecimal): Boolean {
-        return maxAmount >= minAmount && amount >= minAmount && amount <= maxAmount
+        if (maxAmount < minAmount || amount < minAmount || amount > maxAmount) return false
+        val remaining = nativeSolBalanceAfterFee?.subtract(amount) ?: return true
+        return remaining.compareTo(BigDecimal.ZERO) == 0 || remaining >= SOLANA_RENT_EXEMPTION
+    }
+
+    fun hasNativeSolRentIssue(amount: BigDecimal): Boolean {
+        if (amount <= BigDecimal.ZERO || amount < minAmount || amount > maxAmount) return false
+        val remaining = nativeSolBalanceAfterFee?.subtract(amount) ?: return false
+        return remaining > BigDecimal.ZERO && remaining < SOLANA_RENT_EXEMPTION
     }
 }
 
@@ -99,6 +108,12 @@ fun solanaTransferAmountRange(
     } else {
         BigDecimal.ZERO
     }
+    val nativeSolBalanceAfterFee = if (token.isNativeSolAsset()) {
+        val solFee = if (feeToken?.assetId == token.assetId) feeAmount else BigDecimal.ZERO
+        tokenBalance.subtract(solFee)
+    } else {
+        null
+    }
     val maxAmount = when {
         token.isNativeSolAsset() -> {
             val feeTokenEnough = when {
@@ -151,6 +166,7 @@ fun solanaTransferAmountRange(
     return SolanaTransferAmountRange(
         minAmount = minAmount,
         maxAmount = maxAmount.max(BigDecimal.ZERO),
+        nativeSolBalanceAfterFee = nativeSolBalanceAfterFee,
     )
 }
 

--- a/app/src/test/java/one/mixin/android/ui/home/web3/trade/TradeInputTest.kt
+++ b/app/src/test/java/one/mixin/android/ui/home/web3/trade/TradeInputTest.kt
@@ -52,89 +52,26 @@ class TradeInputTest {
     }
 
     @Test
-    fun inMixinNativeSolSwapUsesFullBalance() {
-        assertEquals(
-            BigDecimal("1"),
-            swapSpendableBalance(
-                rawBalance = BigDecimal("1"),
+    fun nativeSolSwapBalanceCheckAllowsFullTransferOrLeavesRent() {
+        val balance = BigDecimal("1")
+
+        assertFalse(isNativeSolSwapBalanceError("1", balance, isNativeSol = true))
+        assertFalse(
+            isNativeSolSwapBalanceError(
+                balance.subtract(SOLANA_RENT_EXEMPTION).toPlainString(),
+                balance,
                 isNativeSol = true,
-                inMixin = true,
             ),
         )
-    }
-
-    @Test
-    fun selfCustodyNativeSolSwapStillReservesRent() {
-        assertEquals(
-            BigDecimal("0.99910912"),
-            swapSpendableBalance(
-                rawBalance = BigDecimal("1"),
-                isNativeSol = true,
-                inMixin = false,
-            ),
-        )
-    }
-
-    @Test
-    fun nonNativeSwapBalanceIsUnchanged() {
-        assertEquals(
-            BigDecimal("1"),
-            swapSpendableBalance(
-                rawBalance = BigDecimal("1"),
-                isNativeSol = false,
-                inMixin = true,
-            ),
-        )
-    }
-
-    @Test
-    fun selfCustodyNonNativeSwapBalanceIsUnchanged() {
-        assertEquals(
-            BigDecimal("1"),
-            swapSpendableBalance(
-                rawBalance = BigDecimal("1"),
-                isNativeSol = false,
-                inMixin = false,
-            ),
-        )
-    }
-
-    @Test
-    fun inMixinNativeSolSwapRejectsAmountsBelowRent() {
         assertTrue(
-            isNativeSolSwapAmountBelowRent(
-                inputText = SOLANA_RENT_EXEMPTION.subtract(BigDecimal("0.00000001")).toPlainString(),
+            isNativeSolSwapBalanceError(
+                balance.subtract(SOLANA_RENT_EXEMPTION).add(BigDecimal("0.00000001")).toPlainString(),
+                balance,
                 isNativeSol = true,
-                inMixin = true,
             ),
         )
-        assertFalse(
-            isNativeSolSwapAmountBelowRent(
-                inputText = SOLANA_RENT_EXEMPTION.toPlainString(),
-                isNativeSol = true,
-                inMixin = true,
-            ),
-        )
-        assertFalse(
-            isNativeSolSwapAmountBelowRent(
-                inputText = "0",
-                isNativeSol = true,
-                inMixin = true,
-            ),
-        )
-        assertFalse(
-            isNativeSolSwapAmountBelowRent(
-                inputText = "0.00000001",
-                isNativeSol = true,
-                inMixin = false,
-            ),
-        )
-        assertFalse(
-            isNativeSolSwapAmountBelowRent(
-                inputText = "0.00000001",
-                isNativeSol = false,
-                inMixin = true,
-            ),
-        )
+        assertTrue(isNativeSolSwapBalanceError("0.9995", balance, isNativeSol = true))
+        assertFalse(isNativeSolSwapBalanceError("0.00000001", balance, isNativeSol = true))
+        assertFalse(isNativeSolSwapBalanceError("0.9995", balance, isNativeSol = false))
     }
 }

--- a/app/src/test/java/one/mixin/android/ui/home/web3/trade/TradeInputTest.kt
+++ b/app/src/test/java/one/mixin/android/ui/home/web3/trade/TradeInputTest.kt
@@ -5,6 +5,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
+import one.mixin.android.web3.SOLANA_RENT_EXEMPTION
 
 class TradeInputTest {
     @Test
@@ -94,6 +95,45 @@ class TradeInputTest {
                 rawBalance = BigDecimal("1"),
                 isNativeSol = false,
                 inMixin = false,
+            ),
+        )
+    }
+
+    @Test
+    fun inMixinNativeSolSwapRejectsAmountsBelowRent() {
+        assertTrue(
+            isNativeSolSwapAmountBelowRent(
+                inputText = SOLANA_RENT_EXEMPTION.subtract(BigDecimal("0.00000001")).toPlainString(),
+                isNativeSol = true,
+                inMixin = true,
+            ),
+        )
+        assertFalse(
+            isNativeSolSwapAmountBelowRent(
+                inputText = SOLANA_RENT_EXEMPTION.toPlainString(),
+                isNativeSol = true,
+                inMixin = true,
+            ),
+        )
+        assertFalse(
+            isNativeSolSwapAmountBelowRent(
+                inputText = "0",
+                isNativeSol = true,
+                inMixin = true,
+            ),
+        )
+        assertFalse(
+            isNativeSolSwapAmountBelowRent(
+                inputText = "0.00000001",
+                isNativeSol = true,
+                inMixin = false,
+            ),
+        )
+        assertFalse(
+            isNativeSolSwapAmountBelowRent(
+                inputText = "0.00000001",
+                isNativeSol = false,
+                inMixin = true,
             ),
         )
     }

--- a/app/src/test/java/one/mixin/android/web3/SolanaTokenHelperTest.kt
+++ b/app/src/test/java/one/mixin/android/web3/SolanaTokenHelperTest.kt
@@ -76,6 +76,20 @@ class SolanaTokenHelperTest {
     }
 
     @Test
+    fun solanaTransferAmountRangeAllowsSplTransferWhenNativeFeeAndAtaRentAreCovered() {
+        val range = solanaTransferAmountRange(
+            token = solanaSplToken(balance = "10"),
+            feeToken = solanaNativeToken(balance = "0.00393016"),
+            feeAmount = BigDecimal("0.001"),
+            recipientAccountState = SolanaRecipientAccountState.NEEDS_TOKEN_ACCOUNT,
+            includeAtaCreationReserve = true,
+        )
+
+        assertEquals(BigDecimal("10"), range.maxAmount)
+        assertTrue(range.canTransfer(BigDecimal("10")))
+    }
+
+    @Test
     fun solanaTransferAmountRangeAllowsGaslessSolSendToZero() {
         val range = solanaTransferAmountRange(
             token = solanaNativeToken(balance = "1"),
@@ -90,16 +104,34 @@ class SolanaTokenHelperTest {
     }
 
     @Test
+    fun solanaTransferAmountRangeAllowsFullNativeSolOrLeavesRent() {
+        val range = solanaTransferAmountRange(
+            token = solanaNativeToken(balance = "1"),
+            feeToken = solanaNativeToken(balance = "1"),
+            feeAmount = BigDecimal("0.01"),
+            recipientAccountState = SolanaRecipientAccountState.EXISTS,
+            allowZeroBalance = true,
+        )
+
+        assertEquals(BigDecimal("0.99"), range.maxAmount)
+        assertTrue(range.canTransfer(BigDecimal("0.99")))
+        assertTrue(range.canTransfer(BigDecimal("0.98910912")))
+        assertFalse(range.canTransfer(BigDecimal("0.9895")))
+    }
+
+    @Test
     fun solanaTransferAmountRangeRequiresRentForNewSolRecipient() {
         val range = solanaTransferAmountRange(
             token = solanaNativeToken(balance = "1"),
             feeToken = solanaNativeToken(balance = "1"),
             feeAmount = BigDecimal("0.01"),
             recipientAccountState = SolanaRecipientAccountState.NEEDS_SYSTEM_ACCOUNT,
+            allowZeroBalance = true,
         )
 
         assertEquals(SOLANA_RENT_EXEMPTION, range.minAmount)
-        assertEquals(BigDecimal("0.98910912"), range.maxAmount)
+        assertEquals(BigDecimal("0.99"), range.maxAmount)
+        assertTrue(range.canTransfer(BigDecimal("0.99")))
     }
 
     @Test


### PR DESCRIPTION
## Summary
- allow native SOL swap and Web3 transfer to use the full balance when the remaining balance is zero
- reject only a positive native SOL remainder below the rent exemption
- preserve SOL fee, system rent, and missing SPL ATA rent checks
- reuse the existing send_sol_for_rent string without adding a new resource

## Validation
- ./gradlew :app:testGooglePlayDebugUnitTest --tests one.mixin.android.ui.home.web3.trade.TradeInputTest --tests one.mixin.android.web3.SolanaTokenHelperTest --no-daemon -Pkotlin.incremental=false
- ./gradlew :app:assembleGooglePlayDebug --no-daemon -Pkotlin.incremental=false

## Database
- No database schema or version changes; CURRENT_VERSION remains 72.