### PR TITLE
fix(wallet): use chain icon for transactions

### DIFF
--- a/app/src/main/java/one/mixin/android/db/web3/Web3TransactionDao.kt
+++ b/app/src/main/java/one/mixin/android/db/web3/Web3TransactionDao.kt
@@ -23,11 +23,12 @@ interface Web3TransactionDao : BaseDao<Web3Transaction> {
             r.symbol as receive_asset_symbol,
             sf.symbol as sponsor_fee_asset_symbol
         FROM transactions w 
-        LEFT JOIN tokens c ON c.asset_id = w.chain_id AND c.wallet_id = :walletId
+        LEFT JOIN tokens ct ON ct.asset_id = w.chain_id AND ct.wallet_id = :walletId
+        LEFT JOIN chains c ON c.chain_id = w.chain_id
         LEFT JOIN tokens s ON s.asset_id = w.send_asset_id AND s.wallet_id = :walletId
         LEFT JOIN tokens r ON r.asset_id = w.receive_asset_id AND r.wallet_id = :walletId
         LEFT JOIN tokens sf ON sf.asset_id = w.sponsor_fee_asset_id AND sf.wallet_id = :walletId
-        WHERE (w.send_asset_id = :assetId OR w.receive_asset_id = :assetId) AND (s.wallet_id = :walletId OR c.wallet_id = :walletId) AND w.level >= (SELECT level FROM tokens WHERE asset_id = :assetId)
+        WHERE (w.send_asset_id = :assetId OR w.receive_asset_id = :assetId) AND (s.wallet_id = :walletId OR ct.wallet_id = :walletId) AND w.level >= (SELECT level FROM tokens WHERE asset_id = :assetId)
         AND w.address in (SELECT destination FROM addresses WHERE wallet_id = :walletId)
         ORDER BY w.transaction_at DESC 
         LIMIT 21
@@ -44,7 +45,7 @@ interface Web3TransactionDao : BaseDao<Web3Transaction> {
             r.symbol as receive_asset_symbol,
             sf.symbol as sponsor_fee_asset_symbol
         FROM transactions w
-        LEFT JOIN tokens c ON c.asset_id = w.chain_id AND c.wallet_id = :walletId
+        LEFT JOIN chains c ON c.chain_id = w.chain_id
         LEFT JOIN tokens s ON s.asset_id = w.send_asset_id AND s.wallet_id = :walletId
         LEFT JOIN tokens r ON r.asset_id = w.receive_asset_id AND r.wallet_id = :walletId
         LEFT JOIN tokens sf ON sf.asset_id = w.sponsor_fee_asset_id AND sf.wallet_id = :walletId
@@ -78,7 +79,7 @@ interface Web3TransactionDao : BaseDao<Web3Transaction> {
     @Query(""" SELECT DISTINCT w.transaction_hash, w.transaction_type, w.status, w.block_number, w.chain_id, w.address, w.fee, w.sponsor_fee_asset_id, w.sponsor_fee_amount, w.senders, w.receivers, w.approvals, w.send_asset_id, w.receive_asset_id, w.transaction_at, w.updated_at, w.level,
         c.symbol chain_symbol, c.icon_url chain_icon_url, s.icon_url send_asset_icon_url, s.symbol send_asset_symbol, r.icon_url receive_asset_icon_url, r.symbol receive_asset_symbol, sf.symbol sponsor_fee_asset_symbol
         FROM transactions w
-        LEFT JOIN tokens c ON c.asset_id = w.chain_id AND c.wallet_id = :walletId
+        LEFT JOIN chains c ON c.chain_id = w.chain_id
         LEFT JOIN tokens s ON s.asset_id = w.send_asset_id AND s.wallet_id = :walletId
         LEFT JOIN tokens r ON r.asset_id = w.receive_asset_id AND r.wallet_id = :walletId
         LEFT JOIN tokens sf ON sf.asset_id = w.sponsor_fee_asset_id AND sf.wallet_id = :walletId

--- a/app/src/main/java/one/mixin/android/ui/wallet/Web3FilterParams.kt
+++ b/app/src/main/java/one/mixin/android/ui/wallet/Web3FilterParams.kt
@@ -117,7 +117,7 @@ class Web3FilterParams(
                 "r.symbol as receive_asset_symbol, " +
                 "sf.symbol as sponsor_fee_asset_symbol " +
                 "FROM transactions w " +
-                "LEFT JOIN tokens c ON c.asset_id = w.chain_id AND c.wallet_id = '$walletId' " +
+                "LEFT JOIN chains c ON c.chain_id = w.chain_id " +
                 "LEFT JOIN tokens s ON s.asset_id = w.send_asset_id AND s.wallet_id = '$walletId' " +
                 "LEFT JOIN tokens r ON r.asset_id = w.receive_asset_id AND r.wallet_id = '$walletId' " +
                 "LEFT JOIN tokens sf ON sf.asset_id = w.sponsor_fee_asset_id AND sf.wallet_id = '$walletId' " +

--- a/app/src/main/java/one/mixin/android/web3/details/Web3TransactionHeaderIcon.kt
+++ b/app/src/main/java/one/mixin/android/web3/details/Web3TransactionHeaderIcon.kt
@@ -58,10 +58,8 @@ internal fun BadgeCircleImageView.bindTransactionHeaderIcon(transaction: Web3Tra
     when (val icon = transaction.resolveHeaderIcon()) {
         is Web3TransactionHeaderIcon.Token -> {
             bg.loadImage(icon.iconUrl, R.drawable.ic_avatar_place_holder)
-            badge.isVisible = !icon.chainIconUrl.isNullOrBlank()
-            if (badge.isVisible) {
-                badge.loadImage(icon.chainIconUrl, R.drawable.ic_avatar_place_holder)
-            }
+            badge.isVisible = true
+            badge.loadImage(icon.chainIconUrl, R.drawable.ic_avatar_place_holder)
         }
 
         is Web3TransactionHeaderIcon.Drawable -> {

--- a/app/src/test/java/one/mixin/android/ui/wallet/Web3FilterParamsChainIconTest.kt
+++ b/app/src/test/java/one/mixin/android/ui/wallet/Web3FilterParamsChainIconTest.kt
@@ -1,0 +1,16 @@
+package one.mixin.android.ui.wallet
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class Web3FilterParamsChainIconTest {
+    @Test
+    fun transactionQueryUsesChainMetadataForNetworkBadge() {
+        val sql = Web3FilterParams(walletId = "wallet").buildQuery().sql
+
+        assertTrue(sql.contains("c.icon_url as chain_icon_url"))
+        assertTrue(sql.contains("LEFT JOIN chains c ON c.chain_id = w.chain_id"))
+        assertFalse(sql.contains("LEFT JOIN tokens c ON c.asset_id = w.chain_id"))
+    }
+}


### PR DESCRIPTION
## Summary
- source transaction network badges from chain metadata
- avoid falling back to native gas token icons
- show the default badge icon when chain metadata has no icon

## Test
- `./gradlew :app:testGooglePlayDebugUnitTest --tests one.mixin.android.ui.wallet.Web3FilterParamsChainIconTest --tests one.mixin.android.ui.wallet.Web3PendingFeeTest --console=plain`