### PR TITLE
fix(referral): allow six-character invitation codes

### DIFF
--- a/app/src/main/java/one/mixin/android/ui/common/profile/InputReferralBottomSheetDialogFragment.kt
+++ b/app/src/main/java/one/mixin/android/ui/common/profile/InputReferralBottomSheetDialogFragment.kt
@@ -193,7 +193,7 @@ class InputReferralBottomSheetDialogFragment : MixinComposeBottomSheetDialogFrag
                             } else {
                                 ActionButton(
                                     text = stringResource(R.string.Review),
-                                    enabled = input.trim().length >= 8,
+                                    enabled = input.trim().length >= 6,
                                     onClick = {
                                         scope.launch(errorHandler) {
                                             uiState = UiState.Loading


### PR DESCRIPTION
Referral codes shorter than eight characters left the Review button disabled. Lower the minimum trimmed input length to six characters so six-character codes can proceed to server validation while preserving support for longer codes.

Validation: `./gradlew :app:compileGooglePlayDebugKotlin --console=plain` and `git diff --check` passed.
